### PR TITLE
add empty test targets

### DIFF
--- a/hack/ci/test.sh
+++ b/hack/ci/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/../..
+cd "${REPO_ROOT}"
+
+go test sigs.k8s.io/kubebuilder-declarative-pattern/pkg/...

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -1,0 +1,1 @@
+package pkg

--- a/pkg/patterns/addon/pkg/doc.go
+++ b/pkg/patterns/addon/pkg/doc.go
@@ -1,0 +1,1 @@
+package pkg

--- a/pkg/patterns/doc.go
+++ b/pkg/patterns/doc.go
@@ -1,0 +1,1 @@
+package patterns


### PR DESCRIPTION
- Add a CI script for prow presubmits
- Add doc.go files to packages that have no go files so go test will
  traverse them.