### PR TITLE
declarative/watch: resume watch on failure

### DIFF
--- a/pkg/patterns/declarative/pkg/watch/dynamic.go
+++ b/pkg/patterns/declarative/pkg/watch/dynamic.go
@@ -18,17 +18,20 @@ package watch
 
 import (
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+// WatchDelay is the time between a Watch being dropped and attempting to resume it
+const WatchDelay = 30 * time.Second
 
 func NewDynamicWatch(config rest.Config) (*dynamicWatch, chan event.GenericEvent, error) {
 	dw := &dynamicWatch{events: make(chan event.GenericEvent)}
@@ -66,32 +69,46 @@ func (dw *dynamicWatch) newDynamicClient(gvk schema.GroupVersionKind) (dynamic.R
 
 // Add registers a watch for changes to 'trigger' filtered by 'options' to raise an event on 'target'
 func (dw *dynamicWatch) Add(trigger schema.GroupVersionKind, options metav1.ListOptions, target metav1.ObjectMeta) error {
-	log := log.Log
-
 	client, err := dw.newDynamicClient(trigger)
 	if err != nil {
 		return fmt.Errorf("creating client for (%s): %v", trigger.String(), err)
 	}
 
-	events, err := client.Watch(options)
-
-	if err != nil {
-		log.WithValues("kind", trigger.String()).WithValues("namespace", target.Namespace).WithValues("labels", options.LabelSelector).Error(err, "adding watch to dynamic client")
-		return fmt.Errorf("adding watch to dynamic client: %v", err)
-	}
-
-	log.WithValues("kind", trigger.String()).WithValues("namespace", target.Namespace).WithValues("options", options.String()).V(2).Info("watch registered")
-	eventChan := events.ResultChan()
-
 	go func() {
-		for clientEvent := range eventChan {
-			if clientEvent.Object == nil || clientEvent.Type == watch.Added {
-				continue
-			}
-			log.WithValues("type", clientEvent.Type).WithValues("kind", trigger.String()).Info("broadcasting event")
-			dw.events <- event.GenericEvent{Object: clientEvent.Object, Meta: &target}
+		for {
+			dw.watchUntilClosed(client, trigger, options, target)
+
+			time.Sleep(WatchDelay)
 		}
 	}()
 
 	return nil
+}
+
+// A Watch will be closed when the pod loses connection to the API server.
+// If a Watch is opened with no ResourceVersion then we will recieve an 'ADDED'
+// event for all Watch objects[1]. This will result in 'overnotification'
+// from this Watch but it will ensure we always Reconcile when needed`.
+//
+// [1] https://github.com/kubernetes/kubernetes/issues/54878#issuecomment-357575276
+func (dw *dynamicWatch) watchUntilClosed(client dynamic.ResourceInterface, trigger schema.GroupVersionKind, options metav1.ListOptions, target metav1.ObjectMeta) {
+	log := log.Log
+
+	events, err := client.Watch(options)
+
+	if err != nil {
+		log.WithValues("kind", trigger.String()).WithValues("namespace", target.Namespace).WithValues("labels", options.LabelSelector).Error(err, "adding watch to dynamic client")
+		return
+	}
+
+	log.WithValues("kind", trigger.String()).WithValues("namespace", target.Namespace).WithValues("labels", options.LabelSelector).Info("watch began")
+
+	for clientEvent := range events.ResultChan() {
+		log.WithValues("type", clientEvent.Type).WithValues("kind", trigger.String()).Info("broadcasting event")
+		dw.events <- event.GenericEvent{Object: clientEvent.Object, Meta: &target}
+	}
+
+	log.WithValues("kind", trigger.String()).WithValues("namespace", target.Namespace).WithValues("labels", options.LabelSelector).Info("watch closed")
+
+	return
 }


### PR DESCRIPTION
A Watch will be dropped by the server periodically. We want to maintain
the watch as long as the operator is running. This change resumes the
Watch then it is closed by the server and maintains the ResourceVersion
to reduce noise.

fixes #7