### PR TITLE
pkg/patterns/addon/init: Drop flag parsing

### DIFF
--- a/pkg/patterns/addon/init.go
+++ b/pkg/patterns/addon/init.go
@@ -11,7 +11,6 @@ var initialized bool
 // Init should be called at the beginning of the main function for all addon operator controllers
 func Init() {
 	flag.Set("logtostderr", "true")
-	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(true))
 
 	initialized = true


### PR DESCRIPTION
This boilerplate is now included at the top of kubebuilder's generated
main() function. Calling it before the generated code results in
main() declared flags from not being recognized.