### PR TITLE
docs/addon/walkthrough: Cleanup pass

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubebuilderdeclarativepattern provides tools to construct
+// declarative Kubernetes operators to manage the lifecycle of a
+// deployment.
+//
+// Getting Started
+//
+// Follow the project documentation for a getting started guide:
+// - https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/tree/master/docs
+package kubebuilderdeclarativepattern

--- a/examples/dashboard-operator/config/default/kustomization.yaml
+++ b/examples/dashboard-operator/config/default/kustomization.yaml
@@ -23,6 +23,7 @@ bases:
 
 patches:
 - manager_image_patch.yaml
+- manager_resource_patch.yaml
 
 vars:
 - name: WEBHOOK_SECRET_NAME

--- a/examples/dashboard-operator/config/default/manager_resource_patch.yaml
+++ b/examples/dashboard-operator/config/default/manager_resource_patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 150Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi


### PR DESCRIPTION
- Remove bazel for direct dockerfile builds.
- Reference actual repo path and don't rely on unimplemented kubebuilder
  flag.
- Rely on kubebuilders RBAC generation and give the set of roles needed
  for the dashboard operator
- Tighten up some language

updates #3