### PR TITLE
examples/dashboard-operator: fake vendor directory

### DIFF
--- a/examples/dashboard-operator/Makefile
+++ b/examples/dashboard-operator/Makefile
@@ -32,7 +32,7 @@ teardown: manifests
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests:
-	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
+	go run ../../vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
 
 # Run go fmt against code
 fmt:
@@ -48,7 +48,9 @@ generate:
 
 # Build the docker image
 docker-build:
-	cp -r ../vendor ./
+	cp -r ../../vendor ./
+	mkdir -p vendor/sigs.k8s.io/kubebuilder-declarative-pattern
+	cp -r ../../pkg vendor/sigs.k8s.io/kubebuilder-declarative-pattern
 	docker build . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
 	sed -i'' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml


### PR DESCRIPTION
Fake the vendoring of the kubebuilder-declarative-operator library by
copying it into vendor in just the right spot.

This odd move is needed to builder the Docker container. I'd like to
make it look as much like the walkthrough as possible, or else I'd
modify the Dockerfile to live at the root of the project.