### PR TITLE
dashboard-operator: default image name to $USER/dashboard-operator

### DIFF
--- a/examples/dashboard-operator/Makefile
+++ b/examples/dashboard-operator/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Image URL to use all building/pushing image targets
-IMG ?= gcr.io/jrjohnson-gke/dashboard-operator:latest
+IMG ?= ${USER}/dashboard-operator:latest
 
 all: test manager
 

--- a/examples/dashboard-operator/config/default/manager_image_patch.yaml
+++ b/examples/dashboard-operator/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/jrjohnson-gke/dashboard-operator:latest
+      - image: /dashboard-operator:latest
         name: manager


### PR DESCRIPTION
This is a more reasonable default for those lucky enough that `$USER == $dockerhub login`