### PR TITLE
Make the default manifest loader pluggable

### DIFF
--- a/pkg/patterns/declarative/options.go
+++ b/pkg/patterns/declarative/options.go
@@ -24,8 +24,17 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/loaders"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
+
+type ManifestLoaderFunc func() ManifestController
+
+// DefaultManifestLoader is the manifest loader we use when a manifest loader is not otherwise configured
+// We curently default to loading from the filesystem, but may change this default in future
+var DefaultManifestLoader ManifestLoaderFunc = func() ManifestController {
+	return loaders.NewManifestLoader()
+}
 
 type reconcilerParams struct {
 	rawManifestOperations []ManifestOperation

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/loaders"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/kubectlcmd"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
@@ -238,10 +237,9 @@ func (r *Reconciler) applyOptions(opts ...reconcilerOption) {
 		params = opt(params)
 	}
 
-	// Default to filesystem manifest controller if not set
-	// TODO: Default to https?
+	// Default the manifest controller if not set
 	if params.manifestController == nil {
-		params.manifestController = loaders.NewManifestLoader()
+		params.manifestController = DefaultManifestLoader()
 	}
 
 	r.options = params


### PR DESCRIPTION
This enables it to be configured or changed.