### PR TITLE
declarative,addon: Configure the filesystem loader in addon.Init

### DIFF
--- a/pkg/patterns/addon/init.go
+++ b/pkg/patterns/addon/init.go
@@ -20,14 +20,25 @@ import (
 	"flag"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/loaders"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative"
 )
 
 var initialized bool
 
 // Init should be called at the beginning of the main function for all addon operator controllers
+//
+// This function configures the environment and declarative library
+// with defaults specific to addons.
 func Init() {
 	flag.Set("logtostderr", "true")
 	logf.SetLogger(logf.ZapLogger(true))
+
+	if declarative.DefaultManifestLoader == nil {
+		declarative.DefaultManifestLoader = func() declarative.ManifestController {
+			return loaders.NewManifestLoader()
+		}
+	}
 
 	initialized = true
 }

--- a/pkg/patterns/declarative/options.go
+++ b/pkg/patterns/declarative/options.go
@@ -24,17 +24,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/loaders"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
 type ManifestLoaderFunc func() ManifestController
 
 // DefaultManifestLoader is the manifest loader we use when a manifest loader is not otherwise configured
-// We curently default to loading from the filesystem, but may change this default in future
-var DefaultManifestLoader ManifestLoaderFunc = func() ManifestController {
-	return loaders.NewManifestLoader()
-}
+var DefaultManifestLoader ManifestLoaderFunc
 
 type reconcilerParams struct {
 	rawManifestOperations []ManifestOperation

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -238,7 +238,7 @@ func (r *Reconciler) applyOptions(opts ...reconcilerOption) {
 	}
 
 	// Default the manifest controller if not set
-	if params.manifestController == nil {
+	if params.manifestController == nil && DefaultManifestLoader != nil {
 		params.manifestController = DefaultManifestLoader()
 	}
 
@@ -251,6 +251,10 @@ func (r *Reconciler) validateOptions() error {
 
 	if r.options.prune && r.options.labelMaker == nil {
 		errs = append(errs, "WithApplyPrune must be used with the WithLabels option")
+	}
+
+	if r.options.manifestController == nil {
+		errs = append(errs, "ManifestController must be set either by configuring DefaultManifestLoader or specifying the WithManifestController option")
 	}
 
 	if len(errs) != 0 {


### PR DESCRIPTION
This change removes the dependency between the declarative and addon
package. This allows non-addon users to utilize the declarative
reconciler with their own manifest loader.