### PR TITLE
declarative,docs: remove packageName

### DIFF
--- a/docs/addon/walkthrough/README.md
+++ b/docs/addon/walkthrough/README.md
@@ -188,7 +188,7 @@ func newReconciler(mgr manager.Manager) *ReconcileDashboard {
 
 	r := &ReconcileDashboard{}
 
-	r.Reconciler.Init(mgr, &api.Dashboard{}, "dashboard",
+	r.Reconciler.Init(mgr, &api.Dashboard{},
 		declarative.WithObjectTransform(declarative.AddLabels(labels)),
 		declarative.WithOwner(declarative.SourceAsOwner),
 		declarative.WithLabels(declarative.SourceLabel(mgr.GetScheme())),

--- a/examples/dashboard-operator/pkg/controller/dashboard/dashboard_controller.go
+++ b/examples/dashboard-operator/pkg/controller/dashboard/dashboard_controller.go
@@ -64,7 +64,7 @@ func newReconciler(mgr manager.Manager) (r *ReconcileDashboard, srcLabels declar
 	r = &ReconcileDashboard{}
 	srcLabels = declarative.SourceLabel(mgr.GetScheme())
 
-	err = r.Reconciler.Init(mgr, &api.Dashboard{}, "dashboard",
+	err = r.Reconciler.Init(mgr, &api.Dashboard{},
 		declarative.WithObjectTransform(declarative.AddLabels(labels)),
 		declarative.WithOwner(declarative.SourceAsOwner),
 		declarative.WithLabels(srcLabels),

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -45,8 +45,7 @@ type Reconciler struct {
 
 	mgr manager.Manager
 
-	packageName string
-	options     reconcilerParams
+	options reconcilerParams
 }
 
 type kubectlClient interface {
@@ -61,9 +60,8 @@ type DeclarativeObject interface {
 // For mocking
 var kubectl = kubectlcmd.New()
 
-func (r *Reconciler) Init(mgr manager.Manager, prototype DeclarativeObject, packageName string, opts ...reconcilerOption) error {
+func (r *Reconciler) Init(mgr manager.Manager, prototype DeclarativeObject, opts ...reconcilerOption) error {
 	r.prototype = prototype
-	r.packageName = packageName
 	r.kubectl = kubectl
 
 	r.client = mgr.GetClient()


### PR DESCRIPTION
The addon manifest loader uses the 'ComponentName()' call on
'CommonSpec' to resolve the component to load the manifest from.

We could do this directly in declarative by requiring packageName and
bubbling it out to the Loader, but there's no reason for the declarative
controller to keep track of this value. The library can't make decisions
about which package to use beyond passing a string it was given.

Pushing this out to the addon/loader allows implementers to own the
decision and perhaps change it at runtime based on the CRs configuration
or the state of CLI flags.

fixes #33