### PR TITLE
Extend Mocks

### DIFF
--- a/pkg/test/mocks/client.go
+++ b/pkg/test/mocks/client.go
@@ -2,15 +2,45 @@ package mocks
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // FakeClient is a struct that implements client.Client for use in tests.
-type FakeClient struct{}
+type FakeClient struct {
+	c             map[client.ObjectKey]runtime.Object
+	ErrIfNotFound bool
+}
 
-func (FakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+func NewClient(c map[client.ObjectKey]runtime.Object) FakeClient {
+	return FakeClient{
+		c: c,
+	}
+}
+
+func (f FakeClient) Get(ctx context.Context, key client.ObjectKey, out runtime.Object) error {
+	obj, ok := f.c[key]
+	if !ok {
+		if f.ErrIfNotFound {
+			return apierrors.NewNotFound(schema.GroupResource{}, key.Name)
+		}
+		// TODO: should always return NotFound error here. Will need to update affected unit tests to stub the
+		// necessary data first.
+		return nil
+	}
+	obj = obj.DeepCopyObject()
+
+	outVal := reflect.ValueOf(out)
+	objVal := reflect.ValueOf(obj)
+	if !objVal.Type().AssignableTo(outVal.Type()) {
+		return fmt.Errorf("cache had type %s, but %s was asked for", objVal.Type(), outVal.Type())
+	}
+	reflect.Indirect(outVal).Set(reflect.Indirect(objVal))
 	return nil
 }
 

--- a/pkg/test/mocks/manager.go
+++ b/pkg/test/mocks/manager.go
@@ -35,6 +35,13 @@ type Manager struct {
 	Scheme *runtime.Scheme
 }
 
+func NewManager(c FakeClient) Manager {
+	return Manager{
+		client: c,
+		cache:  FakeCache{},
+	}
+}
+
 func (Manager) Add(manager.Runnable) error {
 	panic("implement me")
 }


### PR DESCRIPTION
Extend mock support in a couple ways:
> Allow injecting a Client into a mock Manager
> Add key-value response functionality to FakeClient

This allows clients of this repo to write basic tests that add fake objects into the client and retrieve them later.