### PR TITLE
docs/dashboard-operator: switch to example.org

### DIFF
--- a/docs/addon/walkthrough/README.md
+++ b/docs/addon/walkthrough/README.md
@@ -19,7 +19,7 @@ Create a new directory and use kubebuilder to scafold the operator:
 cd $(go env GOPATH)
 mkdir -p src/sigs.k8s.io/dashboard-operator/
 cd src/sigs.k8s.io/dashboard-operator/
-kubebuilder init --domain sigs.k8s.io --license apache2 --owner "The Kubernetes Authors" --dep=true
+kubebuilder init --domain addons.example.org --license apache2 --owner "The Kubernetes Authors" --dep=true
 ```
 
 Add the patterns to your project:

--- a/docs/addon/walkthrough/README.md
+++ b/docs/addon/walkthrough/README.md
@@ -19,7 +19,7 @@ Create a new directory and use kubebuilder to scafold the operator:
 cd $(go env GOPATH)
 mkdir -p src/sigs.k8s.io/dashboard-operator/
 cd src/sigs.k8s.io/dashboard-operator/
-kubebuilder init --domain addons.example.org --license apache2 --owner "The Kubernetes Authors" --dep=true
+kubebuilder init --domain addons.example.org --license apache2 --owner "TODO($USER): assign copyright" --dep=true
 ```
 
 Add the patterns to your project:

--- a/examples/dashboard-operator/config/crds/addons_v1alpha1_dashboard.yaml
+++ b/examples/dashboard-operator/config/crds/addons_v1alpha1_dashboard.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: dashboards.addons.sigs.k8s.io
+  name: dashboards.addons.example.org
 spec:
-  group: addons.sigs.k8s.io
+  group: addons.example.org
   names:
     kind: Dashboard
     plural: dashboards

--- a/examples/dashboard-operator/config/rbac/rbac_role.yaml
+++ b/examples/dashboard-operator/config/rbac/rbac_role.yaml
@@ -11,7 +11,7 @@ rules:
   verbs:
   - list
 - apiGroups:
-  - addons.sigs.k8s.io
+  - addons.example.org
   resources:
   - dashboards
   verbs:

--- a/examples/dashboard-operator/config/samples/addons_v1alpha1_dashboard.yaml
+++ b/examples/dashboard-operator/config/samples/addons_v1alpha1_dashboard.yaml
@@ -1,4 +1,4 @@
-apiVersion: addons.sigs.k8s.io/v1alpha1
+apiVersion: addons.example.org/v1alpha1
 kind: Dashboard
 metadata:
   name: dashboard-sample

--- a/examples/dashboard-operator/pkg/apis/addons/v1alpha1/doc.go
+++ b/examples/dashboard-operator/pkg/apis/addons/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=sigs.k8s.io/kubebuilder-declarative-pattern/examples/dashboard-operator/pkg/apis/addons
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=addons.sigs.k8s.io
+// +groupName=addons.example.org
 package v1alpha1

--- a/examples/dashboard-operator/pkg/apis/addons/v1alpha1/register.go
+++ b/examples/dashboard-operator/pkg/apis/addons/v1alpha1/register.go
@@ -21,7 +21,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=sigs.k8s.io/kubebuilder-declarative-pattern/examples/dashboard-operator/pkg/apis/addons
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=addons.sigs.k8s.io
+// +groupName=addons.example.org
 package v1alpha1
 
 import (
@@ -31,7 +31,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "addons.sigs.k8s.io", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "addons.example.org", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/examples/dashboard-operator/pkg/controller/dashboard/dashboard_controller.go
+++ b/examples/dashboard-operator/pkg/controller/dashboard/dashboard_controller.go
@@ -39,7 +39,7 @@ type ReconcileDashboard struct {
 // for WithApplyPrune
 // +kubebuilder:rbac:groups=*,resources=*,verbs=list
 
-// +kubebuilder:rbac:groups=addons.sigs.k8s.io,resources=dashboards,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=addons.example.org,resources=dashboards,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=apps;extensions,resources=deployments,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;delete;patch

--- a/examples/dashboard-operator/pkg/controller/dashboard/tests/simple.in.yaml
+++ b/examples/dashboard-operator/pkg/controller/dashboard/tests/simple.in.yaml
@@ -1,4 +1,4 @@
-apiVersion: addons.sigs.k8s.io/v1alpha1
+apiVersion: addons.example.org/v1alpha1
 kind: Dashboard
 metadata:
   name: dashboard-sample

--- a/examples/dashboard-operator/pkg/controller/dashboard/tests/simple.out.yaml
+++ b/examples/dashboard-operator/pkg/controller/dashboard/tests/simple.out.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    addons.sigs.k8s.io/dashboard: dashboard-sample
+    addons.example.org/dashboard: dashboard-sample
     k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
@@ -13,7 +13,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    addons.sigs.k8s.io/dashboard: dashboard-sample
+    addons.example.org/dashboard: dashboard-sample
     k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard-certs
   namespace: kube-system
@@ -25,7 +25,7 @@ apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
   labels:
-    addons.sigs.k8s.io/dashboard: dashboard-sample
+    addons.example.org/dashboard: dashboard-sample
     k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
@@ -68,7 +68,7 @@ spec:
     version: ""
   selector:
     matchLabels:
-      addons.sigs.k8s.io/dashboard: dashboard-sample
+      addons.example.org/dashboard: dashboard-sample
 
 ---
 
@@ -76,7 +76,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
-    addons.sigs.k8s.io/dashboard: dashboard-sample
+    addons.example.org/dashboard: dashboard-sample
     k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system
@@ -128,7 +128,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    addons.sigs.k8s.io/dashboard: dashboard-sample
+    addons.example.org/dashboard: dashboard-sample
     k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard-minimal
   namespace: kube-system
@@ -190,7 +190,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    addons.sigs.k8s.io/dashboard: dashboard-sample
+    addons.example.org/dashboard: dashboard-sample
     k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard-minimal
   namespace: kube-system
@@ -209,7 +209,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    addons.sigs.k8s.io/dashboard: dashboard-sample
+    addons.example.org/dashboard: dashboard-sample
     k8s-app: kubernetes-dashboard
   name: kubernetes-dashboard
   namespace: kube-system


### PR DESCRIPTION
k8s.io is reserved for Kubernetes APIs. We don't want users to assume
this domain can be used by any extension or addon. The API group
should be a valid domain controlled by the author (or one dedicated to
examples such as example.{com,net,org})