### PR TITLE
Tolerate multiple calls to addon.Init

### DIFF
--- a/pkg/patterns/addon/init.go
+++ b/pkg/patterns/addon/init.go
@@ -19,44 +19,37 @@ package addon
 import (
 	"context"
 	"flag"
+	"sync"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/loaders"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
-
-var initialized bool
 
 var (
 	privateRegistry = flag.String("private-registry", "", "private image registry, if set overwrites the image repo on all pods")
 	imagePullSecret = flag.String("image-pull-secret", "", "secret used accessing private image registry, if set imagePullSecret annotation is added to all pods")
 )
 
+var initOnce sync.Once
+
 // Init should be called at the beginning of the main function for all addon operator controllers
 //
 // This function configures the environment and declarative library
 // with defaults specific to addons.
 func Init() {
-	flag.Set("logtostderr", "true")
-	logf.SetLogger(logf.ZapLogger(true))
-	log := logf.Log.WithName("addons")
-
-	if declarative.DefaultManifestLoader == nil {
-		declarative.DefaultManifestLoader = func() declarative.ManifestController {
-			return loaders.NewManifestLoader()
+	initOnce.Do(func() {
+		if declarative.DefaultManifestLoader == nil {
+			declarative.DefaultManifestLoader = func() declarative.ManifestController {
+				return loaders.NewManifestLoader()
+			}
 		}
-	}
 
-	declarative.Options.Begin = append(declarative.Options.Begin, declarative.WithObjectTransform(func(ctx context.Context, obj declarative.DeclarativeObject, m *manifest.Objects) error {
-		if *privateRegistry != "" || *imagePullSecret != "" {
-			log.Info("applying private reigstry options")
-			return declarative.ImageRegistryTransform(*privateRegistry, *imagePullSecret)(ctx, obj, m)
-		}
-		return nil
-	}))
-
-	log.Info("initialized")
-
-	initialized = true
+		declarative.Options.Begin = append(declarative.Options.Begin, declarative.WithObjectTransform(func(ctx context.Context, obj declarative.DeclarativeObject, m *manifest.Objects) error {
+			if *privateRegistry != "" || *imagePullSecret != "" {
+				return declarative.ImageRegistryTransform(*privateRegistry, *imagePullSecret)(ctx, obj, m)
+			}
+			return nil
+		}))
+	})
 }


### PR DESCRIPTION
This means we don't need to put a call to addon.Init into main, which
simplifies code generation.  Instead, we call it before we first call
into the addon framework - which means we can do so in the
controllers.