### PR TITLE
Implement Create method in FakeClient

### DIFF
--- a/pkg/test/golden/validator.go
+++ b/pkg/test/golden/validator.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
+	clientScheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/loaders"
@@ -51,6 +52,7 @@ func NewValidator(t *testing.T, b *scheme.Builder) *validator {
 	addon.Init()
 	v.findChannelsPath()
 
+	v.mgr = mocks.NewManager(mocks.NewClient(clientScheme.Scheme))
 	v.mgr.Scheme = v.scheme
 	return v
 }

--- a/pkg/test/mocks/manager.go
+++ b/pkg/test/mocks/manager.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 // Mock Types for Reconciler tests:
@@ -66,7 +68,7 @@ func (m Manager) GetScheme() *runtime.Scheme {
 
 func (m Manager) GetClient() client.Client {
 	if m.client == nil {
-		m.client = FakeClient{}
+		m.client = NewClient(scheme.Scheme)
 	}
 	return m.client
 }


### PR DESCRIPTION
Currently, `FakeClient` doesn't implement `Create` method.
Some tests need to set specific resource object.
This PR implements `Create` method in `FakeClient`.

Fixes: #47

Related: kubernetes-sigs/addon-operators#19