### PR TITLE
Add debug log to functions transforms object

### DIFF
--- a/pkg/patterns/declarative/labels.go
+++ b/pkg/patterns/declarative/labels.go
@@ -31,8 +31,10 @@ import (
 // AddLabels returns an ObjectTransform that adds labels to all the objects
 func AddLabels(labels map[string]string) ObjectTransform {
 	return func(ctx context.Context, o DeclarativeObject, manifest *manifest.Objects) error {
+		log := log.Log
 		// TODO: Add to selectors and labels in templates?
 		for _, o := range manifest.Items {
+			log.WithValues("object", o).WithValues("labels", labels).V(1).Info("add labels to object")
 			o.AddLabels(labels)
 		}
 


### PR DESCRIPTION
This PR adds debug log messages to functions that transform object by `V(1)` logger.

Fixes: #54