### PR TITLE
Fetch manifests over http/https

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
-	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
 	sigs.k8s.io/controller-runtime v0.4.0
+	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/patterns/addon/init.go
+++ b/pkg/patterns/addon/init.go
@@ -40,8 +40,8 @@ var initOnce sync.Once
 func Init() {
 	initOnce.Do(func() {
 		if declarative.DefaultManifestLoader == nil {
-			declarative.DefaultManifestLoader = func() declarative.ManifestController {
-				return loaders.NewManifestLoader()
+			declarative.DefaultManifestLoader = func() (declarative.ManifestController, error) {
+				return loaders.NewManifestLoader(loaders.FlagChannel)
 			}
 		}
 

--- a/pkg/patterns/addon/pkg/loaders/fs.go
+++ b/pkg/patterns/addon/pkg/loaders/fs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,11 +40,14 @@ type ManifestLoader struct {
 
 // NewManifestLoader provides a Repository that resolves versions based on an Addon object
 // and loads manifests from the filesystem.
-func NewManifestLoader() *ManifestLoader {
-	// TODO: Accept as a parameter - but it's hard to have a flag per controller
-	repo := NewFSRepository(FlagChannel)
+func NewManifestLoader(channel string) (*ManifestLoader, error) {
+	if strings.HasPrefix(channel, "http://") || strings.HasPrefix(channel, "https://") {
+		repo := NewHTTPRepository(channel)
+		return &ManifestLoader{repo: repo}, nil
+	}
 
-	return &ManifestLoader{repo: repo}
+	repo := NewFSRepository(channel)
+	return &ManifestLoader{repo: repo}, nil
 }
 
 func (c *ManifestLoader) ResolveManifest(ctx context.Context, object runtime.Object) (string, error) {

--- a/pkg/patterns/addon/pkg/loaders/http.go
+++ b/pkg/patterns/addon/pkg/loaders/http.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loaders
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
+)
+
+// HTTPRepository supports loading from http / https
+type HTTPRepository struct {
+	baseURL string
+}
+
+var _ Repository = &HTTPRepository{}
+
+// NewHTTPRepository constructs an HTTPRepository
+func NewHTTPRepository(baseURL string) *HTTPRepository {
+	return &HTTPRepository{
+		baseURL: baseURL,
+	}
+}
+
+func (r *HTTPRepository) LoadChannel(ctx context.Context, name string) (*Channel, error) {
+	if !allowedChannelName(name) {
+		return nil, fmt.Errorf("invalid channel name: %q", name)
+	}
+
+	log := log.Log
+	log.WithValues("channel", name).WithValues("baseURL", r.baseURL).Info("loading channel")
+
+	p := r.makeURL(name)
+	b, err := r.readURL(p)
+	if err != nil {
+		log.WithValues("path", p).Error(err, "error reading channel")
+		return nil, fmt.Errorf("error reading channel %s: %v", p, err)
+	}
+
+	channel := &Channel{}
+	if err := yaml.Unmarshal(b, channel); err != nil {
+		return nil, fmt.Errorf("error parsing channel %s: %v", p, err)
+	}
+
+	return channel, nil
+}
+
+func (r *HTTPRepository) LoadManifest(ctx context.Context, packageName string, id string) (string, error) {
+	if !allowedManifestId(packageName) {
+		return "", fmt.Errorf("invalid package name: %q", id)
+	}
+
+	if !allowedManifestId(id) {
+		return "", fmt.Errorf("invalid manifest id: %q", id)
+	}
+
+	log := log.Log
+	log.WithValues("package", packageName).Info("loading package")
+
+	p := r.makeURL("packages", packageName, id, "manifest.yaml")
+	b, err := r.readURL(p)
+	if err != nil {
+		return "", fmt.Errorf("error reading package %s: %v", p, err)
+	}
+
+	return string(b), nil
+}
+
+// makeURL joins the paths to the baseURL
+func (r *HTTPRepository) makeURL(paths ...string) string {
+	u := r.baseURL
+	for _, path := range paths {
+		if !strings.HasSuffix(u, "/") {
+			u += "/"
+		}
+		u += path
+	}
+	return u
+}
+
+// readURL tries to fetch the specified url
+func (r *HTTPRepository) readURL(url string) ([]byte, error) {
+	log.Log.WithValues("url", url).Info("doing HTTP request")
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := http.DefaultClient.Do(req)
+	if response != nil {
+		defer response.Body.Close()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error fetching %q: %v", url, err)
+	}
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response for %q: %v", url, err)
+	}
+
+	if response.StatusCode == 200 {
+		return body, nil
+	}
+
+	return nil, fmt.Errorf("unexpected response code %q fetching %q: %v", response.Status, url, string(body))
+}

--- a/pkg/patterns/addon/pkg/loaders/types.go
+++ b/pkg/patterns/addon/pkg/loaders/types.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
 )
 
 type Repository interface {

--- a/pkg/patterns/addon/pkg/loaders/types.go
+++ b/pkg/patterns/addon/pkg/loaders/types.go
@@ -103,7 +103,7 @@ func (r *FSRepository) LoadChannel(ctx context.Context, name string) (*Channel, 
 	}
 
 	channel := &Channel{}
-	if err := yaml.Unmarshal(b, &channel); err != nil {
+	if err := yaml.Unmarshal(b, channel); err != nil {
 		return nil, fmt.Errorf("error parsing channel %s: %v", p, err)
 	}
 

--- a/pkg/patterns/declarative/options.go
+++ b/pkg/patterns/declarative/options.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
-type ManifestLoaderFunc func() ManifestController
+type ManifestLoaderFunc func() (ManifestController, error)
 
 // DefaultManifestLoader is the manifest loader we use when a manifest loader is not otherwise configured
 var DefaultManifestLoader ManifestLoaderFunc


### PR DESCRIPTION
Initial fetching from an http/https channel
    
Currently channels must be explicitly specified with an http:// or
https:// URL, no authentication is supported, etc.
