### PR TITLE
Support multiple packages in a channel manifest file

### DIFF
--- a/docs/addon/walkthrough/README.md
+++ b/docs/addon/walkthrough/README.md
@@ -83,7 +83,8 @@ We need to define the default stable channel, so create `channels/stable`:
 ```bash
 cat > channels/stable <<EOF
 manifests:
-- version: 1.8.3
+- name: dashboard
+  version: 1.8.3
 EOF
 ```
 

--- a/examples/dashboard-operator/channels/stable
+++ b/examples/dashboard-operator/channels/stable
@@ -1,2 +1,3 @@
 manifests:
-- version: 1.8.3
+- name: dashboard
+  version: 1.8.3

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/kubebuilder-declarative-pattern
 go 1.12
 
 require (
+	github.com/blang/semver v3.5.0+incompatible
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
@@ -10,5 +11,6 @@ require (
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
+	k8s.io/klog v0.4.0
 	sigs.k8s.io/controller-runtime v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.1-coreos.6/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pkg/patterns/addon/pkg/loaders/fs.go
+++ b/pkg/patterns/addon/pkg/loaders/fs.go
@@ -74,7 +74,7 @@ func (c *ManifestLoader) ResolveManifest(ctx context.Context, object runtime.Obj
 			return "", err
 		}
 
-		version, err := channel.Latest()
+		version, err := channel.Latest(componentName)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/patterns/addon/pkg/loaders/types.go
+++ b/pkg/patterns/addon/pkg/loaders/types.go
@@ -23,7 +23,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/blang/semver"
 	yaml "gopkg.in/yaml.v2"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -136,19 +138,54 @@ type Channel struct {
 }
 
 type Version struct {
-	Version string
+	Package string `json:"name"`
+	Version string `json:"version"`
 }
 
-func (c *Channel) Latest() (*Version, error) {
+func (c *Channel) Latest(packageName string) (*Version, error) {
 	var latest *Version
 	for i := range c.Manifests {
 		v := &c.Manifests[i]
+		if v.Package != "" && v.Package != packageName {
+			continue
+		}
 		if latest == nil {
 			latest = v
-		} else {
-			return nil, fmt.Errorf("version selection not implemented")
+		} else if latest.Compare(v) < 0 {
+			// Tie-break by taking the later version
+			latest = v
 		}
 	}
 
 	return latest, nil
+}
+
+// Compare compares two Versions, returning >0 for l>r, =0 if l=r, <0 if l<r
+func (l *Version) Compare(r *Version) int {
+	// If the package name is specified, it "wins"
+	if l.Package != r.Package {
+		if l.Package == "" {
+			return -1
+		}
+		if r.Package == "" {
+			return 1
+		}
+	}
+
+	lSemver, lErr := semver.ParseTolerant(l.Version)
+	rSemver, rErr := semver.ParseTolerant(r.Version)
+	if lErr != nil {
+		klog.Warningf("invalid semver in version %+v", l)
+		if rErr != nil {
+			klog.Warningf("invalid semver in version %+v", r)
+			return 0
+		}
+		return -1
+	}
+	if rErr != nil {
+		klog.Warningf("invalid semver in version %+v", r)
+		return 1
+	}
+
+	return lSemver.Compare(rSemver)
 }

--- a/pkg/patterns/addon/pkg/loaders/versions_test.go
+++ b/pkg/patterns/addon/pkg/loaders/versions_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loaders
+
+import (
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	grid := []struct {
+		Bigger  Version
+		Smaller Version
+	}{
+		// Basic ordering applies
+		{
+			Bigger:  Version{Package: "", Version: "2.0.0"},
+			Smaller: Version{Package: "", Version: "1.0.0"},
+		},
+		// Parsing is tolerant
+		{
+			Bigger:  Version{Package: "", Version: "1"},
+			Smaller: Version{Package: "", Version: "0.1"},
+		},
+		// Named packages have higher priority
+		{
+			Bigger:  Version{Package: "foo", Version: "v1"},
+			Smaller: Version{Package: "", Version: "v1"},
+		},
+		// Valid versions are higher priority than invalid versions
+		{
+			Bigger:  Version{Package: "", Version: "v1"},
+			Smaller: Version{Package: "", Version: "corrupt2"},
+		},
+	}
+
+	for _, g := range grid {
+		{
+			l := &g.Bigger
+			r := &g.Smaller
+			v := l.Compare(r)
+
+			if v <= 0 {
+				t.Errorf("comparison failed: %+v vs %+v was %d", l, r, v)
+			}
+		}
+
+		{
+			l := &g.Smaller
+			r := &g.Bigger
+			v := l.Compare(r)
+
+			if v >= 0 {
+				t.Errorf("comparison failed: %+v vs %+v was %d", l, r, v)
+			}
+		}
+
+		{
+			l := &g.Bigger
+			r := &g.Bigger
+			v := l.Compare(r)
+
+			if v != 0 {
+				t.Errorf("comparison failed: %+v vs %+v was %d", l, r, v)
+			}
+		}
+
+		{
+			l := &g.Smaller
+			r := &g.Smaller
+			v := l.Compare(r)
+
+			if v != 0 {
+				t.Errorf("comparison failed: %+v vs %+v was %d", l, r, v)
+			}
+		}
+	}
+}

--- a/pkg/test/mocks/client.go
+++ b/pkg/test/mocks/client.go
@@ -2,8 +2,8 @@ package mocks
 
 import (
 	"context"
-
 	"encoding/json"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
We now allow a package name to be specified, but manifests with no
name are assumed to match all packages.  Where there is a tie, we
prefer a named package, and then we prefer the newer version.

(Previous version of this commit was a breaking change ... no longer)