### PR TITLE
controller-runtime: pkg/runtime/log moved to pkg/log

### DIFF
--- a/pkg/patterns/declarative/image.go
+++ b/pkg/patterns/declarative/image.go
@@ -21,8 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/log"
-
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 


### PR DESCRIPTION
Another update to follow the controller-runtime package deprecation,
that I missed last time because of concurrent PRs.