### PR TITLE
Use guestbook-operator in smoketest

### DIFF
--- a/examples/guestbook-operator/Dockerfile
+++ b/examples/guestbook-operator/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY vendor/ vendor/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/examples/guestbook-operator/Makefile
+++ b/examples/guestbook-operator/Makefile
@@ -38,6 +38,11 @@ deploy: manifests
 	cd config/manager && kustomize edit set image controller=${IMG}
 	kustomize build config/default | kubectl apply -f -
 
+# Teardown controller in the configured Kubernetes cluster in ~/.kube/config
+# This command does things that can't always re-run so the exit codes are ignored
+teardown: manifests
+	kustomize build config/default | kubectl delete -f - || true
+
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
@@ -50,12 +55,15 @@ fmt:
 vet:
 	go vet ./...
 
+vendor:
+	go mod vendor
+
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
-docker-build: test
+docker-build: vendor test
 	docker build . -t ${IMG}
 
 # Push the docker image
@@ -78,3 +86,4 @@ CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
+

--- a/examples/guestbook-operator/config/manager/kustomization.yaml
+++ b/examples/guestbook-operator/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/examples/guestbook-operator/go.mod
+++ b/examples/guestbook-operator/go.mod
@@ -7,7 +7,5 @@ require (
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
 	sigs.k8s.io/controller-runtime v0.4.0
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-00010101000000-000000000000
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200317144824-bbf1fb2a4a9a
 )
-
-replace sigs.k8s.io/kubebuilder-declarative-pattern => ../../

--- a/examples/guestbook-operator/go.sum
+++ b/examples/guestbook-operator/go.sum
@@ -589,6 +589,8 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jC
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
 sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9NPsg=
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
+sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200317144824-bbf1fb2a4a9a h1:UdSbADtqxVDTwICFMWXVmjPyzSn+xfaYmxjHa2jPrj0=
+sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200317144824-bbf1fb2a4a9a/go.mod h1:UmLMohI25YTEDjmGhTZ3eiE9DPEfxtbAykwZFQJ92g8=
 sigs.k8s.io/kustomize/api v0.2.0 h1:e++6JpysnnlUbHmFrv6jvfF5rFlgQ103bS1DO7r5bWA=
 sigs.k8s.io/kustomize/api v0.2.0/go.mod h1:zVtMg179jW1gr74jo9fc2Ac9dLYLTZZThc3DDb9lDW4=
 sigs.k8s.io/kustomize/pseudo/k8s v0.1.0 h1:otg4dLFc03c3gzl+2CV8GPGcd1kk8wjXwD+UhhcCn5I=

--- a/hack/smoketest.go
+++ b/hack/smoketest.go
@@ -52,7 +52,8 @@ import (
 )
 
 const (
-	defaultSystemNamespace = "kube-system"
+	// Set default namespace for your operator.
+	defaultSystemNamespace = "guestbook-operator-system"
 )
 
 type (
@@ -125,7 +126,7 @@ func main() {
 
 	var operators []AddonTest
 	for _, test := range []AddonTest{
-		NewDashboardTest(c),
+		NewGuestbookTest(c),
 	} {
 		if _, ignored := ignore[test.Name()]; ignored {
 			log.Printf("ignoring test: %s", test.Name())
@@ -568,20 +569,20 @@ func (c *CommonAddonTest) VerifyDown() error {
 	return fmt.Errorf("VerifyDown not implemented for operator: %s", c.Name())
 }
 
-type DashboardTest struct {
+type GuestbookTest struct {
 	CommonAddonTest
 }
 
-func NewDashboardTest(c CommonAddonTest) *DashboardTest {
-	t := &DashboardTest{CommonAddonTest: c}
-	t.Base = "../examples/dashboard-operator"
+func NewGuestbookTest(c CommonAddonTest) *GuestbookTest {
+	t := &GuestbookTest{CommonAddonTest: c}
+	t.Base = "../examples/guestbook-operator"
 	return t
 }
 
-func (k *DashboardTest) VerifyUp() error {
+func (k *GuestbookTest) VerifyUp() error {
 	h := k.Harness
 
-	err := verifyReadyPods(h, defaultSystemNamespace, "kubernetes-dashboard")
+	err := verifyReadyPods(h, defaultSystemNamespace, "guestbook-operator")
 	if err != nil {
 		return err
 	}
@@ -589,13 +590,13 @@ func (k *DashboardTest) VerifyUp() error {
 	return nil
 }
 
-func (t *DashboardTest) Disrupt() {
-	_, err := executeCommand("kubectl", "delete", "all", "-l", "k8s-app=kubernetes-dashboard", "-n", defaultSystemNamespace)
+func (t *GuestbookTest) Disrupt() {
+	_, err := executeCommand("kubectl", "delete", "all", "-l", "example-app=guestbook", "-n", defaultSystemNamespace)
 	if err != nil {
 		glog.Warningf("kubectl delete finished with error: %v", err)
 	}
 }
 
-func (k *DashboardTest) VerifyDown() error {
-	return verifyNoWorkloadsWithLabel("k8s-app=kubernetes-dashboard", defaultSystemNamespace)
+func (k *GuestbookTest) VerifyDown() error {
+	return verifyNoWorkloadsWithLabel("example-app=guestbook", defaultSystemNamespace)
 }


### PR DESCRIPTION
In PR #81, dashboard-operator is removed in this repository.
It is needed that change to use guestbook-operator in `hack/smoketest.go` instead of dashboard-operator.

related to: #80