### PR TITLE
Use log instead of klog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,12 @@ require (
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/onsi/gomega v1.7.0
+	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
-	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.4.0
 	sigs.k8s.io/kustomize/api v0.2.0
 	sigs.k8s.io/yaml v1.1.0

--- a/pkg/patterns/addon/pkg/loaders/types.go
+++ b/pkg/patterns/addon/pkg/loaders/types.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
@@ -184,15 +183,15 @@ func (l *Version) Compare(r *Version) int {
 	lSemver, lErr := semver.ParseTolerant(l.Version)
 	rSemver, rErr := semver.ParseTolerant(r.Version)
 	if lErr != nil {
-		klog.Warningf("invalid semver in version %+v", l)
+		log.Log.Info("invalid semver in version", "version", l)
 		if rErr != nil {
-			klog.Warningf("invalid semver in version %+v", r)
+			log.Log.Info("invalid semver in version", "version", r)
 			return 0
 		}
 		return -1
 	}
 	if rErr != nil {
-		klog.Warningf("invalid semver in version %+v", r)
+		log.Log.Info("invalid semver in version", "version", r)
 		return 1
 	}
 


### PR DESCRIPTION
For consistency, we should use log instead of klog in the semver comparison
logic.