### PR TITLE
Log yaml and error when we fail to parse

### DIFF
--- a/pkg/patterns/declarative/pkg/manifest/objects.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects.go
@@ -32,7 +32,7 @@ import (
 // Objects holds a collection of objects, so that we can filter / sequence them
 type Objects struct {
 	Items []*Object
-	Blobs [][] byte
+	Blobs [][]byte
 }
 
 type Object struct {
@@ -332,7 +332,7 @@ func ParseObjects(ctx context.Context, manifest string) (*Objects, error) {
 		out := &unstructured.Unstructured{}
 		err := decoder.Decode(out)
 		if err != nil {
-			log.V(2).Info("Unable to parse into Unstructured, Storing as blob")
+			log.WithValues("error", err).WithValues("yaml", yaml).V(2).Info("Unable to parse into Unstructured, storing as blob")
 			objects.Blobs = append(objects.Blobs, []byte(yaml))
 		} else {
 			// We don't reuse the manifest because it's probably yaml, and we want to use json


### PR DESCRIPTION
This makes the message more actionable and self-explanatory.