### PR TITLE
Don't use kubectl --validate

### DIFF
--- a/pkg/patterns/declarative/options.go
+++ b/pkg/patterns/declarative/options.go
@@ -45,7 +45,8 @@ type reconcilerParams struct {
 
 	prune             bool
 	preserveNamespace bool
-	kustomize    	  bool
+	kustomize         bool
+	validate          bool
 
 	sink       Sink
 	ownerFn    OwnerSelector
@@ -169,6 +170,14 @@ func WithManagedApplication(labelMaker LabelMaker) reconcilerOption {
 		p.objectTransformations = append(p.objectTransformations, func(ctx context.Context, instance DeclarativeObject, objects *manifest.Objects) error {
 			return transformApplication(ctx, instance, objects, labelMaker)
 		})
+		return p
+	}
+}
+
+// WithApplyValidation enables validation with kubectl apply
+func WithApplyValidation() reconcilerOption {
+	return func(p reconcilerParams) reconcilerParams {
+		p.validate = true
 		return p
 	}
 }

--- a/pkg/patterns/declarative/pkg/kubectlcmd/client.go
+++ b/pkg/patterns/declarative/pkg/kubectlcmd/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,7 +49,7 @@ func (console) Run(c *exec.Cmd) error {
 }
 
 // Apply runs the kubectl apply with the provided manifest argument
-func (c *Client) Apply(ctx context.Context, namespace string, manifest string, extraArgs ...string) error {
+func (c *Client) Apply(ctx context.Context, namespace string, manifest string, validate bool, extraArgs ...string) error {
 	log := log.Log
 
 	log.Info("applying manifest")
@@ -57,6 +58,11 @@ func (c *Client) Apply(ctx context.Context, namespace string, manifest string, e
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
+
+	// Not doing --validate avoids downloading the OpenAPI
+	// which can save a lot work & memory
+	args = append(args, "--validate="+strconv.FormatBool(validate))
+
 	args = append(args, extraArgs...)
 	args = append(args, "-f", "-")
 

--- a/pkg/patterns/declarative/pkg/kubectlcmd/client_test.go
+++ b/pkg/patterns/declarative/pkg/kubectlcmd/client_test.go
@@ -43,6 +43,7 @@ func TestKubectlApply(t *testing.T) {
 		name       string
 		namespace  string
 		manifest   string
+		validate   bool
 		args       []string
 		err        error
 		expectArgs []string
@@ -51,17 +52,24 @@ func TestKubectlApply(t *testing.T) {
 			name:       "manifest",
 			namespace:  "",
 			manifest:   "foo",
-			expectArgs: []string{"kubectl", "apply", "-f", "-"},
+			expectArgs: []string{"kubectl", "apply", "--validate=false", "-f", "-"},
 		},
 		{
 			name:       "manifest with apply",
 			namespace:  "kube-system",
 			manifest:   "heynow",
-			expectArgs: []string{"kubectl", "apply", "-n", "kube-system", "-f", "-"},
+			expectArgs: []string{"kubectl", "apply", "-n", "kube-system", "--validate=false", "-f", "-"},
+		},
+		{
+			name:       "manifest with validate",
+			namespace:  "",
+			manifest:   "foo",
+			validate:   true,
+			expectArgs: []string{"kubectl", "apply", "--validate=true", "-f", "-"},
 		},
 		{
 			name:       "error propagation",
-			expectArgs: []string{"kubectl", "apply", "-f", "-"},
+			expectArgs: []string{"kubectl", "apply", "--validate=false", "-f", "-"},
 			err:        errors.New("error"),
 		},
 		{
@@ -69,7 +77,7 @@ func TestKubectlApply(t *testing.T) {
 			namespace:  "kube-system",
 			manifest:   "heynow",
 			args:       []string{"--prune=true", "--prune-whitelist=hello-world"},
-			expectArgs: []string{"kubectl", "apply", "-n", "kube-system", "--prune=true", "--prune-whitelist=hello-world", "-f", "-"},
+			expectArgs: []string{"kubectl", "apply", "-n", "kube-system", "--validate=false", "--prune=true", "--prune-whitelist=hello-world", "-f", "-"},
 		},
 	}
 
@@ -77,7 +85,7 @@ func TestKubectlApply(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cs := collector{Error: test.err}
 			kubectl := &Client{cmdSite: &cs}
-			err := kubectl.Apply(context.Background(), test.namespace, test.manifest, test.args...)
+			err := kubectl.Apply(context.Background(), test.namespace, test.manifest, test.validate, test.args...)
 
 			if test.err != nil && err == nil {
 				t.Error("expected error to occur")

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -54,7 +54,7 @@ type Reconciler struct {
 }
 
 type kubectlClient interface {
-	Apply(ctx context.Context, namespace string, manifest string, args ...string) error
+	Apply(ctx context.Context, namespace string, manifest string, validate bool, args ...string) error
 }
 
 type DeclarativeObject interface {
@@ -155,7 +155,6 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 		manifestStr = m
 	}
 
-
 	extraArgs := []string{"--force"}
 
 	if r.options.prune {
@@ -172,7 +171,7 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 		ns = name.Namespace
 	}
 
-	if err := r.kubectl.Apply(ctx, ns, manifestStr, extraArgs...); err != nil {
+	if err := r.kubectl.Apply(ctx, ns, manifestStr, r.options.validate, extraArgs...); err != nil {
 		log.Error(err, "applying manifest")
 		return reconcile.Result{}, fmt.Errorf("error applying manifest: %v", err)
 	}


### PR DESCRIPTION
It needs to download the whole OpenAPI spec, which is very expensive
in terms of memory (and generally).  As we expect to tightly control
our manifest, it isn't very useful anyway.

Expose an option WithApplyValidation to use the legacy behaviour.