### PR TITLE
Fix incorrect path for Kustomize in addon operators

### DIFF
--- a/pkg/patterns/declarative/pkg/manifest/objects.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects.go
@@ -33,6 +33,7 @@ import (
 type Objects struct {
 	Items []*Object
 	Blobs [][]byte
+	Path  string
 }
 
 type Object struct {


### PR DESCRIPTION
Kustomize cannot find the `kustomization.yaml` file for creating the final manifest.

The error before this fix:
```
2020-04-17T13:13:20.045-0400	ERROR	running kustomize to create final manifest	{"error": "unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/'"}
github.com/go-logr/zapr.(*zapLogger).Error
	/Users/srajan/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative.(*Reconciler).reconcileExists
	/Users/srajan/go/pkg/mod/sigs.k8s.io/kubebuilder-declarative-pattern@v0.0.0-20200415210853-85eb326a6add/pkg/patterns/declarative/reconciler.go:145
sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative.(*Reconciler).Reconcile
	/Users/srajan/go/pkg/mod/sigs.k8s.io/kubebuilder-declarative-pattern@v0.0.0-20200415210853-85eb326a6add/pkg/patterns/declarative/reconciler.go:106
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/Users/srajan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:256
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/Users/srajan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:232
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/Users/srajan/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.0/pkg/internal/controller/controller.go:211
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
	/Users/srajan/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/Users/srajan/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
	/Users/srajan/go/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/wait/wait.go:88
2020-04-17T13:13:20.251-0400	ERROR	controller-runtime.controller	Reconciler error	{"controller": "coredns-controller", "request": "kube-system/coredns-operator", "error": "error running kustomize: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/'"}
```

This PR fixes the error and also updates the test to reflect the case where an operator uses Kustomize

Probable related issue: #56 