### PR TITLE
Add Reconciliation Metrics Functionality

### DIFF
--- a/docs/addon/walkthrough/README.md
+++ b/docs/addon/walkthrough/README.md
@@ -155,6 +155,7 @@ func (r *GuestbookReconciler) setupReconciler(mgr ctrl.Manager) error {
 		declarative.WithStatus(status.NewBasic(mgr.GetClient())),
 		declarative.WithPreserveNamespace(),
 		declarative.WithApplyPrune(),
+		declarative.WithReconcileMetrics(0, nil),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.13
 require (
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/go-logr/logr v0.1.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v1.0.0
 	golang.org/x/tools v0.0.0-20200714190737-9048b464a08d
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	k8s.io/api v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -452,6 +452,7 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -482,6 +483,7 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -512,6 +514,7 @@ golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/patterns/declarative/metrics.go
+++ b/pkg/patterns/declarative/metrics.go
@@ -1,0 +1,600 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package declarative
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
+)
+
+const emptyNamespace = "_Empty_"
+const clusterScoped = "_Cluster_"
+
+const (
+	Declarative = "declarative_reconciler"
+)
+
+const (
+	ReconcileCount   = "reconcile_count"
+	ReconcileFailure = "reconcile_failure_count"
+
+	ManagedObjectsRecord = "managed_objects_record"
+)
+
+var metricsRegisterOnce *sync.Once = &sync.Once{}
+
+var (
+	reconcileCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: Declarative,
+		Name:      ReconcileCount,
+		Help:      "How many times reconciliation of K8s objects managed by declarative reconciler occurs",
+	}, []string{"group_version_kind", "namespace", "name"})
+
+	reconcileFailure = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: Declarative,
+		Name:      ReconcileFailure,
+		Help:      "How many times reconciliation failure of K8s objects managed by declarative reconciler occurs",
+	}, []string{"group_version_kind", "namespace", "name"})
+
+	managedObjectsRecord = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: Declarative,
+		Name:      ManagedObjectsRecord,
+		Help:      "Track the number of objects in manifest",
+	}, []string{"group_version_kind", "namespace", "name"})
+)
+
+var metricsList = []prometheus.Collector{reconcileCount, reconcileFailure, managedObjectsRecord}
+
+func gvkString(gvk schema.GroupVersionKind) string {
+	if len(gvk.Group) == 0 && gvk.Version == "v1" {
+		return gvk.Version + "/" + gvk.Kind
+	}
+
+	return gvk.Group + "/" + gvk.Version + "/" + gvk.Kind
+}
+
+func namespaced(mgr manager.Manager, gvk schema.GroupVersionKind) (bool, error) {
+	mapping, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return false, err
+	}
+
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+type reconcileMetrics struct {
+	groupVersionKind           string
+	reconcileCounterVec        *prometheus.CounterVec
+	reconcileFailureCounterVec *prometheus.CounterVec
+}
+
+func reconcileMetricsFor(gvk schema.GroupVersionKind) reconcileMetrics {
+	return reconcileMetrics{groupVersionKind: gvkString(gvk),
+		reconcileCounterVec: reconcileCount, reconcileFailureCounterVec: reconcileFailure}
+}
+
+func (rm *reconcileMetrics) reconcileWith(req reconcile.Request) {
+	rm.reconcileCounterVec.WithLabelValues(rm.groupVersionKind, req.Namespace, req.Name).Inc()
+}
+
+func (rm *reconcileMetrics) reconcileFailedWith(req reconcile.Request, _ reconcile.Result, err error) {
+	if err != nil {
+		rm.reconcileFailureCounterVec.WithLabelValues(rm.groupVersionKind, req.Namespace, req.Name).Inc()
+	}
+}
+
+type objectRecorder struct {
+	groupVersionKind string
+	gaugeVec         *prometheus.GaugeVec
+}
+
+func objectRecorderFor(gvk schema.GroupVersionKind) objectRecorder {
+	return objectRecorder{groupVersionKind: gvkString(gvk), gaugeVec: managedObjectsRecord}
+}
+
+func (or objectRecorder) Set(namespace, name string, num float64) {
+	if namespace == emptyNamespace || namespace == clusterScoped {
+		or.gaugeVec.WithLabelValues(or.groupVersionKind, "", name).Set(num)
+	} else {
+		or.gaugeVec.WithLabelValues(or.groupVersionKind, namespace, name).Set(num)
+	}
+}
+
+func (or objectRecorder) Unset(namespace, name string) {
+	if namespace == emptyNamespace || namespace == clusterScoped {
+		or.gaugeVec.DeleteLabelValues(or.groupVersionKind, "", name)
+	} else {
+		or.gaugeVec.DeleteLabelValues(or.groupVersionKind, namespace, name)
+	}
+}
+
+var globalObjectTracker *ObjectTracker = NewObjectTracker()
+
+// GetMetricsDuration function returns current metricsDuration
+// of package-scoped internal variable of type *ObjectTracker.
+// It is safe to call this function from multiple go routines
+// with another go routines calling SetMetricsDuration function.
+func GetMetricsDuration() int {
+	return globalObjectTracker.GetMetricsDuration()
+}
+
+// SetMetricsDuration function sets metricsDuration of package
+// scoped internal variable of type *ObjectTracker.
+// It is safe to call this function from multiple go routines
+// with another go routines calling GetMetricsDuration function.
+func SetMetricsDuration(metricsDuration int) {
+	globalObjectTracker.SetMetricsDuration(metricsDuration)
+}
+
+// Type ObjectTracker manages metricsDuration of k8s objects
+// managed by controller(s)
+type ObjectTracker struct {
+	mu              sync.Mutex
+	mgr             manager.Manager
+	metricsDuration int
+	trackedGVK      map[schema.GroupVersionKind]*gvkTracker
+}
+
+// GetMetricsDuration method returns current metricsDuration.
+// It is safe to call this function from multiple go routines
+// with another go routines calling SetMetricsDuration method.
+func (ot *ObjectTracker) GetMetricsDuration() int {
+	ot.mu.Lock()
+	defer ot.mu.Unlock()
+
+	return ot.metricsDuration
+}
+
+// SetMetricsDuration method sets metricsDuration.
+// It is safe to call this function from multiple go routines
+// with another go routines calling GetMetricsDuration method..
+func (ot *ObjectTracker) SetMetricsDuration(metricsDuration int) {
+	ot.mu.Lock()
+	defer ot.mu.Unlock()
+
+	ot.metricsDuration = metricsDuration
+}
+
+func (ot *ObjectTracker) setMetricsDurationInternal(i int) {
+	ot.mu.Lock()
+	defer ot.mu.Unlock()
+
+	if i > 0 && i > ot.metricsDuration {
+		ot.metricsDuration = i
+	}
+}
+
+// Call this before kubectl.Apply
+func (ot *ObjectTracker) addIfNotPresent(objects []*manifest.Object, defaultNamespace string) errors.Aggregate {
+	ot.mu.Lock()
+	defer ot.mu.Unlock()
+	defer ot.deleteMetricsIfNeeded()
+	defer ot.inc()
+
+	var errs []error
+
+	for _, object := range objects {
+		gvk, ns, name := object.GroupVersionKind(),
+			object.UnstructuredObject().GetNamespace(),
+			object.UnstructuredObject().GetName()
+
+		// Check default namespace
+		if defaultNamespace != "" {
+			ns = defaultNamespace
+		}
+
+		namespaced, err := namespaced(ot.mgr, gvk)
+		if err != nil {
+			errs = append(errs, newNoRESTMapperErr(err, gvk))
+			continue
+		}
+
+		if namespaced {
+			if len(ns) == 0 {
+				ns = emptyNamespace
+				errs = append(errs, newEmptyNamespaceErr(gvk, object.UnstructuredObject().GetName()))
+			}
+		} else {
+			ns = clusterScoped
+		}
+
+		if gvkt, ok := ot.trackedGVK[gvk]; ok {
+			if !gvkt.resetIfItHas(ns, name) {
+				gvkt.insert(ns, name)
+			}
+			continue
+		}
+
+		ot.trackedGVK[gvk] = newGVKTracker(ot.mgr, object.UnstructuredObject(), namespaced)
+		ot.trackedGVK[gvk].insert(ns, name)
+
+		// addIfNotPresent is called at Reconcler.reconcileExists,
+		// so Controller & Manager is already running
+		ot.trackedGVK[gvk].start()
+	}
+
+	return errors.NewAggregate(errs)
+}
+
+// Call after ot.mu.Lock()
+func (ot *ObjectTracker) inc() {
+	for _, gvkt := range ot.trackedGVK {
+		gvkt.list.inc()
+	}
+}
+
+// Call after ot.mu.Lock()
+func (ot *ObjectTracker) deleteMetricsIfNeeded() {
+	if ot.metricsDuration > 0 {
+		for _, gvkt := range ot.trackedGVK {
+			gvkt.deleteMetricsIfNeeded(ot.metricsDuration)
+		}
+	}
+}
+
+// NewObjectTracker returns new instance of *ObjectTracker
+func NewObjectTracker() *ObjectTracker {
+	ot := &ObjectTracker{}
+	ot.mgr = nil
+	ot.trackedGVK = make(map[schema.GroupVersionKind]*gvkTracker)
+
+	return ot
+}
+
+type noRESTMapperErr struct {
+	gvk        schema.GroupVersionKind
+	wrappedErr error
+}
+
+func (noREST noRESTMapperErr) Error() string {
+	return noREST.wrappedErr.Error()
+}
+
+func (noRESTMapperErr) Is(target error) bool {
+	_, ok := target.(noRESTMapperErr)
+	return ok
+}
+
+func newNoRESTMapperErr(err error, gvk schema.GroupVersionKind) noRESTMapperErr {
+	return noRESTMapperErr{gvk: gvk, wrappedErr: err}
+}
+
+type emptyNamespaceErr struct {
+	gvk  schema.GroupVersionKind
+	name string
+}
+
+func (emptyNamespaceErr) Error() string {
+	return "Scoped object, but no namespace specified"
+}
+
+func (emptyNamespaceErr) Is(target error) bool {
+	_, ok := target.(emptyNamespaceErr)
+	return ok
+}
+
+func newEmptyNamespaceErr(gvk schema.GroupVersionKind, name string) emptyNamespaceErr {
+	return emptyNamespaceErr{gvk: gvk, name: name}
+}
+
+type gvkTracker struct {
+	list         *items
+	src          source.Source
+	eventHandler handler.EventHandler
+	predicate    predicate.Predicate
+	recorder     objectRecorder
+}
+
+func (gvkt *gvkTracker) insert(namespace string, names ...string) {
+	gvkt.list.insert(namespace, names...)
+}
+
+func (gvkt *gvkTracker) resetIfItHas(namespace, name string) bool {
+	return gvkt.list.resetIfItHas(namespace, name)
+}
+
+func (gvkt *gvkTracker) deleteMetricsIfNeeded(metricsDuration int) {
+	if deleted, pairs := gvkt.list.deleteIfNeeded(metricsDuration); deleted {
+		for ns := range pairs {
+			for _, n := range pairs[ns] {
+				gvkt.recorder.Unset(ns, n)
+			}
+		}
+	}
+}
+
+func (gvkt *gvkTracker) start() {
+	gvkt.src.Start(gvkt.eventHandler, dummyQueue{}, gvkt.predicate)
+}
+
+func newGVKTracker(mgr manager.Manager, obj *unstructured.Unstructured, namespaced bool) (gvkt *gvkTracker) {
+	gvkt = &gvkTracker{}
+	gvkt.list = newItems()
+	gvkt.recorder = objectRecorderFor(obj.GroupVersionKind())
+	gvkt.src = source.NewKindWithCache(obj, mgr.GetCache())
+	gvkt.predicate = predicate.Funcs{}
+	gvkt.eventHandler = recordTrigger{gvkt.list, namespaced, gvkt.recorder}
+
+	return
+}
+
+var _ workqueue.RateLimitingInterface = dummyQueue{}
+
+type dummyQueue struct{}
+
+func (dummyQueue) Add(item interface{})                              {}
+func (dummyQueue) Len() int                                          { return 0 }
+func (dummyQueue) Get() (item interface{}, shutdown bool)            { return struct{}{}, false }
+func (dummyQueue) Done(item interface{})                             {}
+func (dummyQueue) ShutDown()                                         {}
+func (dummyQueue) ShuttingDown() bool                                { return false }
+func (dummyQueue) AddAfter(item interface{}, duration time.Duration) {}
+func (dummyQueue) AddRateLimited(item interface{})                   {}
+func (dummyQueue) Forget(item interface{})                           {}
+func (dummyQueue) NumRequeues(item interface{}) int                  { return 0 }
+
+// Namespace & list of Name pairs
+type nsnPairs map[string][]string
+
+// ids holds namespace/name pairs and is indexed as ids[namespace][name]
+type items struct {
+	mu  sync.Mutex
+	ids map[string]record
+}
+
+func (i *items) insert(namespace string, names ...string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if _, ok := i.ids[namespace]; !ok {
+		i.ids[namespace] = record{}
+	}
+	i.ids[namespace].Insert(names...)
+
+}
+
+func (i *items) has(namespace, name string) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	_, ok := i.ids[namespace]
+	return ok && i.ids[namespace].Has(name)
+}
+
+// Only used by another *items methods
+func (i *items) internalHas(namespace, name string) bool {
+	_, ok := i.ids[namespace]
+	return ok && i.ids[namespace].Has(name)
+}
+
+func (i *items) hasPairs(nsnp nsnPairs) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	for ns, nlist := range nsnp {
+		for _, n := range nlist {
+			if !i.internalHas(ns, n) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (i *items) inc() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	for ns := range i.ids {
+		i.ids[ns].Inc()
+	}
+}
+
+func (i *items) resetIfItHas(namespace, name string) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if _, has := i.ids[namespace]; has {
+		return i.ids[namespace].ResetIfItHas(name)
+	}
+	return false
+}
+
+func (i *items) markDeletedIfItHas(namespace, name string) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if _, has := i.ids[namespace]; has {
+		return i.ids[namespace].MarkDeletedIfItHas(name)
+	}
+	return false
+}
+
+func (i *items) deleteIfNeeded(metricsDuration int) (b bool, p nsnPairs) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	p = make(map[string][]string)
+	for ns := range i.ids {
+		for n := range i.ids[ns] {
+			if i.ids[ns].DeleteIfNeeded(n, metricsDuration) {
+				b = true
+				if _, ok := p[ns]; !ok {
+					p[ns] = []string{}
+				}
+				p[ns] = append(p[ns], n)
+			}
+		}
+		if len(i.ids[ns]) == 0 {
+			delete(i.ids, ns)
+		}
+	}
+
+	return b, p
+}
+
+func newItems() *items {
+	it := &items{}
+	it.ids = make(map[string]record)
+	return it
+}
+
+type record map[string]*counter
+
+type counter struct {
+	count   int
+	deleted bool
+}
+
+func (r record) Insert(names ...string) {
+	for _, name := range names {
+		r[name] = &counter{}
+	}
+}
+
+func (r record) Has(name string) bool {
+	_, has := r[name]
+	return has
+}
+
+func (r record) Inc() {
+	for i := range r {
+		if r[i].deleted {
+			r[i].count++
+		}
+	}
+}
+
+func (r record) ResetIfItHas(name string) bool {
+	var has bool
+	if _, has = r[name]; has && r[name].deleted {
+		r[name] = &counter{}
+	}
+	return has
+}
+
+func (r record) MarkDeletedIfItHas(name string) bool {
+	if _, has := r[name]; has {
+		r[name].deleted = true
+		return true
+	}
+	return false
+}
+
+func (r record) DeleteIfNeeded(name string, limit int) bool {
+	if _, has := r[name]; has {
+		if r[name].deleted && r[name].count >= limit {
+			delete(r, name)
+			return true
+		}
+	}
+	return false
+}
+
+var _ handler.EventHandler = recordTrigger{}
+
+type recordTrigger struct {
+	list       *items
+	namespaced bool
+	recorder   objectRecorder
+}
+
+func (rt recordTrigger) Create(ev event.CreateEvent, _ workqueue.RateLimitingInterface) {
+	ns, name := ev.Meta.GetNamespace(), ev.Meta.GetName()
+
+	if rt.namespaced {
+		if len(ns) == 0 {
+			ns = emptyNamespace
+		}
+	} else {
+		ns = clusterScoped
+	}
+
+	if rt.list.has(ns, name) {
+		rt.recorder.Set(ns, name, float64(1))
+	}
+}
+
+func (rt recordTrigger) Update(ev event.UpdateEvent, _ workqueue.RateLimitingInterface) {
+	var nsnp nsnPairs = make(map[string][]string)
+	ons, oname := ev.MetaOld.GetNamespace(), ev.MetaOld.GetName()
+	nns, nname := ev.MetaNew.GetNamespace(), ev.MetaNew.GetName()
+
+	if rt.namespaced {
+		if len(ons) == 0 {
+			ons = emptyNamespace
+		}
+		if len(nns) == 0 {
+			nns = emptyNamespace
+		}
+	} else {
+		ons = clusterScoped
+		nns = clusterScoped
+	}
+
+	nsnp[ons] = append(nsnp[ons], oname)
+	nsnp[nns] = append(nsnp[nns], nname)
+	// Because objectTracker.addIfNotPresent is called before
+	// kubectl.Apply in Reconciler.reconcileExists,
+	// all pair of oldObj & newObj in DeltaFIFO is in rt.list
+	if !rt.list.hasPairs(nsnp) {
+		return
+	}
+
+	if ons == nns && oname == nname {
+		rt.recorder.Set(ons, oname, float64(1))
+		return
+	}
+	rt.recorder.Set(ons, oname, float64(0))
+	rt.recorder.Set(nns, nname, float64(1))
+}
+
+func (rt recordTrigger) Delete(ev event.DeleteEvent, _ workqueue.RateLimitingInterface) {
+	ns, name := ev.Meta.GetNamespace(), ev.Meta.GetName()
+
+	if rt.namespaced {
+		if len(ns) == 0 {
+			ns = emptyNamespace
+		}
+	} else {
+		ns = clusterScoped
+	}
+
+	if rt.list.markDeletedIfItHas(ns, name) {
+		rt.recorder.Set(ns, name, float64(0))
+	}
+}
+
+func (rt recordTrigger) Generic(ev event.GenericEvent, _ workqueue.RateLimitingInterface) {}

--- a/pkg/patterns/declarative/metrics_test.go
+++ b/pkg/patterns/declarative/metrics_test.go
@@ -1,0 +1,575 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package declarative
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
+	"sigs.k8s.io/yaml"
+)
+
+// This test checks gvkString function
+func TestGVKString(t *testing.T) {
+	testCases := []struct {
+		subtest string
+		gvk     schema.GroupVersionKind
+		want    string
+	}{
+		{
+			subtest: "v1/Pod",
+			gvk:     core.SchemeGroupVersion.WithKind("Pod"),
+			want:    "v1/Pod",
+		},
+		{
+			subtest: "apps/v1/Deployment",
+			gvk:     apps.SchemeGroupVersion.WithKind("Deployment"),
+			want:    "apps/v1/Deployment",
+		},
+	}
+
+	for _, st := range testCases {
+		t.Run(st.subtest, func(t *testing.T) {
+			if got := gvkString(st.gvk); st.want != got {
+				t.Errorf("want:\n%v\ngot:\n%v\n", st.want, got)
+			}
+		})
+	}
+}
+
+// This test checks reconcileMetricsFor function & reconcieMetrics.reconcileWith method
+func TestReconcileWith(t *testing.T) {
+	testCases := []struct {
+		subtest    string
+		gvks       []schema.GroupVersionKind
+		namespaces []string
+		names      []string
+		want       []string
+	}{
+		{
+			subtest:    "core",
+			gvks:       []schema.GroupVersionKind{core.SchemeGroupVersion.WithKind("Pod")},
+			namespaces: []string{"ns1"},
+			names:      []string{"n1"},
+			want: []string{`
+			# HELP declarative_reconciler_reconcile_count How many times reconciliation of K8s objects managed by declarative reconciler occurs
+			# TYPE declarative_reconciler_reconcile_count counter
+			declarative_reconciler_reconcile_count {group_version_kind = "v1/Pod", name = "n1", namespace = "ns1"} 2
+			`,
+			},
+		},
+		{
+			subtest:    "core&app",
+			gvks:       []schema.GroupVersionKind{core.SchemeGroupVersion.WithKind("Pod"), apps.SchemeGroupVersion.WithKind("Deployment")},
+			namespaces: []string{"ns1", ""},
+			names:      []string{"n1", "n2"},
+			want: []string{`
+			# HELP declarative_reconciler_reconcile_count How many times reconciliation of K8s objects managed by declarative reconciler occurs
+			# TYPE declarative_reconciler_reconcile_count counter
+			declarative_reconciler_reconcile_count {group_version_kind = "v1/Pod", name = "n1", namespace = "ns1"} 2
+			`,
+				`
+			# HELP declarative_reconciler_reconcile_count How many times reconciliation of K8s objects managed by declarative reconciler occurs
+			# TYPE declarative_reconciler_reconcile_count counter
+			declarative_reconciler_reconcile_count {group_version_kind = "apps/v1/Deployment", name = "n2", namespace = ""} 2
+			`,
+			},
+		},
+		{
+			subtest:    "node - cluster scoped only",
+			gvks:       []schema.GroupVersionKind{core.SchemeGroupVersion.WithKind("Node")},
+			namespaces: []string{""},
+			names:      []string{"n1"},
+			want: []string{`
+			# HELP declarative_reconciler_reconcile_count How many times reconciliation of K8s objects managed by declarative reconciler occurs
+			# TYPE declarative_reconciler_reconcile_count counter
+			declarative_reconciler_reconcile_count {group_version_kind = "v1/Node", name = "n1", namespace = ""} 2
+			`,
+			},
+		},
+	}
+
+	for _, st := range testCases {
+		t.Run(st.subtest, func(t *testing.T) {
+			for i, gvk := range st.gvks {
+				rm := reconcileMetricsFor(gvk)
+
+				rm.reconcileWith(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: st.namespaces[i], Name: st.names[i]}})
+				rm.reconcileWith(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: st.namespaces[i], Name: st.names[i]}})
+
+				if err := testutil.CollectAndCompare(rm.reconcileCounterVec.WithLabelValues(gvkString(gvk),
+					st.namespaces[i], st.names[i]), strings.NewReader(st.want[i])); err != nil {
+
+					t.Error(err)
+				}
+			}
+		})
+
+		reconcileCount.Reset()
+	}
+}
+
+// This test checks reconcileMetricsFor function & reconcileMetrics.reconcileFailedWith method
+func TestReconcileFailedWith(t *testing.T) {
+	testCases := []struct {
+		subtest    string
+		gvks       []schema.GroupVersionKind
+		errs       []error
+		namespaces []string
+		names      []string
+		want       []string
+	}{
+		{
+			subtest:    "core",
+			gvks:       []schema.GroupVersionKind{core.SchemeGroupVersion.WithKind("Pod")},
+			errs:       []error{errors.New("test")},
+			namespaces: []string{"ns1"},
+			names:      []string{"n1"},
+			want: []string{`
+			# HELP declarative_reconciler_reconcile_failure_count How many times reconciliation failure of K8s objects managed by declarative reconciler occurs
+			# TYPE declarative_reconciler_reconcile_failure_count counter
+			declarative_reconciler_reconcile_failure_count {group_version_kind = "v1/Pod", name = "n1", namespace = "ns1"} 2
+			`,
+			},
+		},
+		{
+			subtest:    "core&app",
+			gvks:       []schema.GroupVersionKind{core.SchemeGroupVersion.WithKind("Pod"), apps.SchemeGroupVersion.WithKind("Deployment")},
+			errs:       []error{errors.New("test"), errors.New("test")},
+			namespaces: []string{"ns1", ""},
+			names:      []string{"n1", "n2"},
+			want: []string{`
+			# HELP declarative_reconciler_reconcile_failure_count How many times reconciliation failure of K8s objects managed by declarative reconciler occurs
+			# TYPE declarative_reconciler_reconcile_failure_count counter
+			declarative_reconciler_reconcile_failure_count {group_version_kind = "v1/Pod", name = "n1", namespace = "ns1"} 2
+			`,
+				`
+			# HELP declarative_reconciler_reconcile_failure_count How many times reconciliation failure of K8s objects managed by declarative reconciler occurs
+			# TYPE declarative_reconciler_reconcile_failure_count counter
+			declarative_reconciler_reconcile_failure_count {group_version_kind = "apps/v1/Deployment", name = "n2", namespace = ""} 2
+			`,
+			},
+		},
+		{
+			subtest:    "node - cluster scoped only",
+			gvks:       []schema.GroupVersionKind{core.SchemeGroupVersion.WithKind("Node")},
+			errs:       []error{errors.New("test")},
+			namespaces: []string{""},
+			names:      []string{"n1"},
+			want: []string{`
+			# HELP declarative_reconciler_reconcile_failure_count How many times reconciliation failure of K8s objects managed by declarative reconciler occurs
+			# TYPE declarative_reconciler_reconcile_failure_count counter
+			declarative_reconciler_reconcile_failure_count {group_version_kind = "v1/Node", name = "n1", namespace = ""} 2
+			`,
+			},
+		},
+		{
+			subtest:    "no error",
+			gvks:       []schema.GroupVersionKind{core.SchemeGroupVersion.WithKind("Node")},
+			errs:       []error{nil},
+			namespaces: []string{""},
+			names:      []string{"n1"},
+			want: []string{`
+			# HELP declarative_reconciler_reconcile_failure_count How many times reconciliation failure of K8s objects managed by declarative reconciler occurs
+			# TYPE declarative_reconciler_reconcile_failure_count counter
+			declarative_reconciler_reconcile_failure_count {group_version_kind = "v1/Node", name = "n1", namespace = ""} 0
+			`,
+			},
+		},
+	}
+
+	for _, st := range testCases {
+		t.Run(st.subtest, func(t *testing.T) {
+			for i, gvk := range st.gvks {
+				rm := reconcileMetricsFor(gvk)
+
+				rm.reconcileFailedWith(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: st.namespaces[i], Name: st.names[i]}},
+					reconcile.Result{}, st.errs[i])
+				rm.reconcileFailedWith(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: st.namespaces[i], Name: st.names[i]}},
+					reconcile.Result{}, st.errs[i])
+
+				if err := testutil.CollectAndCompare(rm.reconcileFailureCounterVec.WithLabelValues(gvkString(gvk),
+					st.namespaces[i], st.names[i]), strings.NewReader(st.want[i])); err != nil {
+
+					t.Error(err)
+				}
+			}
+		})
+
+		reconcileFailure.Reset()
+	}
+}
+
+// This test checks *ObjectTracker.addIfNotPresent method
+//
+// envtest package used in this test requires control
+// plane binaries (etcd & kube-apiserver & kubectl).
+// The default path these binaries reside in is set to
+// /usr/local/kubebuilder/bin .
+// This path can be set through environment variable
+// KUBEBUILDER_ASSETS .
+// It is recommended to download kubebuilder release binaries
+// and point that path.
+func TestAddIfNotPresent(t *testing.T) {
+	const defKubectlPath = "/usr/local/kubebuilder/bin"
+	var kubectlPath string
+
+	// Run local kube-apiserver & etecd
+	testEnv := envtest.Environment{}
+	restConf, err := testEnv.Start()
+	if err != nil {
+		t.Log("Maybe, you have to make sure control plane binaries" + " " +
+			"(kube-apiserver, etcd & kubectl) reside in" + " " +
+			"/usr/local/kubebuilder/bin" + " " +
+			"or have to set environment variable" + " " +
+			"KUBEBUILDER_ASSETS to the path these binaries reside in")
+		t.Error(err)
+	}
+
+	// Create manager
+	mgrOpt := manager.Options{}
+	mgr, err := manager.New(restConf, mgrOpt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	stopC := make(chan struct{})
+	go func() {
+		_ = mgr.GetCache().Start(stopC)
+	}()
+
+	// Set up kubectl command
+	if envPath := os.Getenv("KUBEBUILDER_ASSETS"); envPath != "" {
+		kubectlPath = filepath.Join(envPath, "kubectl")
+	} else {
+		kubectlPath = filepath.Join("/usr/local/kubebuilder/bin", "kubectl")
+	}
+
+	// kubectl arg for "kubectl apply"
+	applyArgs := []string{"apply"}
+	applyArgs = append(applyArgs, "--server="+restConf.Host)
+
+	// kubectl arg for "kubectl delete"
+	deleteArgs := []string{"delete"}
+	deleteArgs = append(deleteArgs, "--server="+restConf.Host)
+
+	// Configure globalObjectTracker
+	globalObjectTracker.mgr = mgr
+
+	testCases := []struct {
+		subtest          string
+		metricsDuration  int
+		actions          []string
+		defaultNamespace string
+		objects          [][]string
+		wants            []string
+	}{
+		// It's better to use different kind of K8s object for each test cases
+		{
+			subtest:          "Create K8s object",
+			metricsDuration:  0,
+			actions:          []string{"Create"},
+			defaultNamespace: "",
+			objects: [][]string{
+				{
+					"kind: Namespace\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: ns1\n",
+				},
+			},
+			wants: []string{
+				`
+				# HELP declarative_reconciler_managed_objects_record Track the number of objects in manifest
+				# TYPE declarative_reconciler_managed_objects_record gauge
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Namespace", name = "ns1", namespace = ""} 1
+				`,
+			},
+		},
+		{
+			subtest:          "Update K8s object",
+			metricsDuration:  0,
+			actions:          []string{"Create", "Update"},
+			defaultNamespace: "",
+			objects: [][]string{
+				{
+					"kind: Namespace\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: ns2\n",
+					"kind: Role\n" +
+						"apiVersion: rbac.authorization.k8s.io/v1\n" +
+						"metadata:\n" +
+						"   name: r2\n" +
+						"   namespace: ns2\n" +
+						"rules:\n" +
+						`   - apiGroups: [""]` + "\n" +
+						`     resources: ["pods"]` + "\n" +
+						`     verbs: ["get"]`,
+				},
+				{
+					"kind: Namespace\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: ns2\n",
+					"kind: Role\n" +
+						"apiVersion: rbac.authorization.k8s.io/v1\n" +
+						"metadata:\n" +
+						"   name: r2\n" +
+						"   namespace: ns2\n" +
+						"rules:\n" +
+						`   - apiGroups: [""]` + "\n" +
+						`     resources: ["pods"]` + "\n" +
+						`     verbs: ["get", "list"]`,
+				},
+			},
+			wants: []string{
+				`
+				# HELP declarative_reconciler_managed_objects_record Track the number of objects in manifest
+				# TYPE declarative_reconciler_managed_objects_record gauge
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Namespace", name = "ns2", namespace = ""} 1
+				declarative_reconciler_managed_objects_record {group_version_kind = "rbac.authorization.k8s.io/v1/Role", name = "r2", namespace = "ns2"} 1
+				`,
+				`
+				# HELP declarative_reconciler_managed_objects_record Track the number of objects in manifest
+				# TYPE declarative_reconciler_managed_objects_record gauge
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Namespace", name = "ns2", namespace = ""} 1
+				declarative_reconciler_managed_objects_record {group_version_kind = "rbac.authorization.k8s.io/v1/Role", name = "r2", namespace = "ns2"} 1
+				`,
+			},
+		},
+		{
+			subtest:          "Delete K8s object",
+			metricsDuration:  0,
+			actions:          []string{"Create", "Delete"},
+			defaultNamespace: "ns3",
+			objects: [][]string{
+				{
+					"kind: Namespace\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: ns3\n",
+					"kind: Secret\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: s3\n" +
+						"type: Opaque\n" +
+						"data:\n" +
+						"   name: dGVzdA==\n",
+				},
+				{
+					"kind: Secret\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: s3\n" +
+						"type: Opaque\n" +
+						"data:\n" +
+						"   name: dGVzdA==\n",
+				},
+			},
+			wants: []string{
+				`
+				# HELP declarative_reconciler_managed_objects_record Track the number of objects in manifest
+				# TYPE declarative_reconciler_managed_objects_record gauge
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Namespace", name = "ns3", namespace = ""} 1
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Secret", name = "s3", namespace = "ns3"} 1
+				`,
+				`
+				# HELP declarative_reconciler_managed_objects_record Track the number of objects in manifest
+				# TYPE declarative_reconciler_managed_objects_record gauge
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Namespace", name = "ns3", namespace = ""} 1
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Secret", name = "s3", namespace = "ns3"} 0
+				`,
+			},
+		},
+		{
+			subtest:          "Delete metrics after specified duration(duration=2)",
+			metricsDuration:  2,
+			actions:          []string{"Create", "Delete", "Create", "Create"},
+			defaultNamespace: "",
+			objects: [][]string{
+				{
+					"kind: Namespace\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: ns4\n",
+					"kind: Secret\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: s4\n" +
+						"   namespace: ns4\n" +
+						"type: Opaque\n" +
+						"data:\n" +
+						"   name: dGVzdA==\n",
+				},
+				{
+					"kind: Secret\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: s4\n" +
+						"   namespace: ns4\n" +
+						"type: Opaque\n" +
+						"data:\n" +
+						"   name: dGVzdA==\n",
+				},
+				{
+					"kind: Namespace\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: ns4\n",
+				},
+				{
+					"kind: Namespace\n" +
+						"apiVersion: v1\n" +
+						"metadata:\n" +
+						"   name: ns4\n",
+				},
+			},
+			wants: []string{
+				`
+				# HELP declarative_reconciler_managed_objects_record Track the number of objects in manifest
+				# TYPE declarative_reconciler_managed_objects_record gauge
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Namespace", name = "ns4", namespace = ""} 1
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Secret", name = "s4", namespace = "ns4"} 1
+				`,
+				`
+				# HELP declarative_reconciler_managed_objects_record Track the number of objects in manifest
+				# TYPE declarative_reconciler_managed_objects_record gauge
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Namespace", name = "ns4", namespace = ""} 1
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Secret", name = "s4", namespace = "ns4"} 0
+				`,
+				`
+				# HELP declarative_reconciler_managed_objects_record Track the number of objects in manifest
+				# TYPE declarative_reconciler_managed_objects_record gauge
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Namespace", name = "ns4", namespace = ""} 1
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Secret", name = "s4", namespace = "ns4"} 0
+				`,
+				`
+				# HELP declarative_reconciler_managed_objects_record Track the number of objects in manifest
+				# TYPE declarative_reconciler_managed_objects_record gauge
+				declarative_reconciler_managed_objects_record {group_version_kind = "v1/Namespace", name = "ns4", namespace = ""} 1
+				`,
+			},
+		},
+	}
+
+	for _, st := range testCases {
+		t.Run(st.subtest, func(t *testing.T) {
+			globalObjectTracker.SetMetricsDuration(st.metricsDuration)
+
+			for i, yobjList := range st.objects {
+				var cmd *exec.Cmd
+				var stdout bytes.Buffer
+				var stderr bytes.Buffer
+				var cmdArgs []string
+
+				var yobj string
+				var jobjList = [][]byte{}
+				var objList = []*manifest.Object{}
+
+				for i, yitem := range yobjList {
+					if i == 0 {
+						yobj = yitem
+					} else {
+						yobj = yobj + "---\n" + yitem
+					}
+				}
+
+				// YAML to JSON
+				for _, yitem := range yobjList {
+					jobj, err := yaml.YAMLToJSON([]byte(yitem))
+					if err != nil {
+						t.Error(err)
+					}
+					jobjList = append(jobjList, jobj)
+				}
+
+				// JSON to manifest.Object
+				for _, jobj := range jobjList {
+					mobj, err := manifest.ParseJSONToObject(jobj)
+					if err != nil {
+						t.Error(err)
+					}
+					objList = append(objList, mobj)
+				}
+
+				// Run addIfNotPresent
+				err = globalObjectTracker.addIfNotPresent(objList, st.defaultNamespace)
+				if err != nil {
+					t.Error(err)
+				}
+
+				// Set up kubectl command
+				if st.actions[i] != "Delete" {
+					if len(st.defaultNamespace) != 0 {
+						cmdArgs = append(applyArgs, "-n", st.defaultNamespace, "-f", "-")
+					} else {
+						cmdArgs = append(applyArgs, "-f", "-")
+					}
+				} else {
+					if len(st.defaultNamespace) != 0 {
+						cmdArgs = append(deleteArgs, "-n", st.defaultNamespace, "-f", "-")
+					} else {
+						cmdArgs = append(deleteArgs, "-f", "-")
+					}
+				}
+				cmd = exec.Command(kubectlPath, cmdArgs...)
+				cmd.Stdin = strings.NewReader(yobj)
+				cmd.Stdout = &stdout
+				cmd.Stderr = &stderr
+
+				if err := cmd.Run(); err != nil {
+					t.Logf("action: %v\n", st.actions[i])
+					t.Logf("stdout: %v\n", stdout.String())
+					t.Logf("stderr: %v\n", stderr.String())
+					t.Error(err)
+				}
+
+				// Wait for reflector sees K8s object change in K8s API server & adds it to DeltaFIFO
+				// then controller pops it and eventhandler updates metrics
+				// If we ommit it, there is a chance call of testutil.CollectAndCompare is too fast & fails.
+				_ = mgr.GetCache().WaitForCacheSync(stopC)
+				time.Sleep(time.Second * 10)
+
+				// Check for metrics
+				err = testutil.CollectAndCompare(managedObjectsRecord, strings.NewReader(st.wants[i]))
+				if err != nil {
+					t.Logf("No. of action in subtest: %v\n", i)
+					t.Error(err)
+				}
+			}
+
+		})
+
+		managedObjectsRecord.Reset()
+	}
+}


### PR DESCRIPTION
This commit
* adds two metrics
  - Count the number of reconciliation & failure of reconciliation
  - Track the number of objects in manifest

* modifies walkthrough example to mention this metrics functionality

* and deletes
   * reconcilerParams.groupVersionKind option
   * WithGroupVersionKind function

Added two metrics are registered to controller-runtime Prometheus registry

This PR is related to #65 .