### PR TITLE
.gitignore: don't ignore vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-vendor/
 # Emacs
 *~
 \#*\#


### PR DESCRIPTION
Now that we are using go.mod and not shipping the vendor directory, we
no longer want to ignore those files (as they shouldn't exist).