### PR TITLE
Modify apply logic in direct.go

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -2,12 +2,11 @@ package applier
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
-	"strings"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
-	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/kubectl/pkg/cmd/apply"
 	cmdDelete "k8s.io/kubectl/pkg/cmd/delete"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -27,24 +26,41 @@ func (d *DirectApplier) Apply(ctx context.Context,
 	validate bool,
 	extraArgs ...string,
 ) error {
-	ioStreams := genericclioptions.IOStreams{
-		In:     os.Stdin,
-		Out:    os.Stdout,
-		ErrOut: os.Stderr,
-	}
-	restClient := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
-	ioReader := strings.NewReader(manifest)
 
-	b := resource.NewBuilder(restClient)
-	res := b.Unstructured().Stream(ioReader, "manifestString").Do()
-	infos, err := res.Infos()
+	tmpFile, err := ioutil.TempFile("", "tmp-manifest-*.yaml")
 	if err != nil {
 		return err
 	}
+	tmpFile.Write([]byte(manifest))
+	tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+	ioStreams := genericclioptions.IOStreams{
+		In:     tmpFile,
+		Out:    os.Stdout,
+		ErrOut: os.Stderr,
+	}
 
+	restClient := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+	f := cmdutil.NewFactory(restClient)
+	schema, err := f.Validator(validate)
+	if err != nil {
+		return err
+	}
 	applyOpts := apply.NewApplyOptions(ioStreams)
-	applyOpts.Namespace = namespace
-	applyOpts.SetObjects(infos)
+
+	applyOpts.DynamicClient, err = f.DynamicClient()
+	if err != nil {
+		return err
+	}
+	applyOpts.DeleteOptions = applyOpts.DeleteFlags.ToOptions(applyOpts.DynamicClient, applyOpts.IOStreams)
+
+	applyOpts.Namespace, applyOpts.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	if namespace != "" {
+		applyOpts.Namespace = namespace
+	}
+	applyOpts.Validator = schema
+	applyOpts.Builder = f.NewBuilder()
+	applyOpts.Mapper, err = f.ToRESTMapper()
 	applyOpts.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
 		applyOpts.PrintFlags.NamePrintFlags.Operation = operation
 		cmdutil.PrintFlagsWithDryRunStrategy(applyOpts.PrintFlags, applyOpts.DryRunStrategy)
@@ -53,6 +69,7 @@ func (d *DirectApplier) Apply(ctx context.Context,
 	applyOpts.DeleteOptions = &cmdDelete.DeleteOptions{
 		IOStreams: ioStreams,
 	}
+	applyOpts.DeleteOptions.Filenames = []string{tmpFile.Name()}
 
 	return applyOpts.Run()
 }


### PR DESCRIPTION
This PR changes a logic to apply in `direct.go`, because current codes ignores some features which are validate and namespace defaulting, etc.

I would like to add tests for this topics later.