### PR TITLE
github actions tests: replace set-env with GITHUB_ENV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           stable: true
 
       - run: |
-          echo "::set-env name=GOPATH::${HOME}/go"
+          echo "GOPATH=${HOME}/go" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
 
@@ -43,7 +43,7 @@ jobs:
           stable: true
 
       - run: |
-          echo "::set-env name=GOPATH::${HOME}/go"
+          echo "GOPATH=${HOME}/go" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
set-env is deprecated for security reasons, so move to the new GITHUB_ENV approach.