### PR TITLE
*: remove non-std library errors packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,9 @@ require (
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/go-logr/logr v0.2.1
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/tools v0.0.0-20200714190737-9048b464a08d
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/cli-runtime v0.19.2

--- a/pkg/test/golden/validator.go
+++ b/pkg/test/golden/validator.go
@@ -19,6 +19,7 @@ package golden
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -26,7 +27,6 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -294,7 +294,7 @@ func diffFiles(t *testing.T, expectedPath, actual string) error {
 
 	actualTmp, err := writeTmp(actual)
 	if err != nil {
-		return xerrors.Errorf("write actual yaml to temp file failed: %w", err)
+		return fmt.Errorf("write actual yaml to temp file failed: %w", err)
 	}
 	t.Logf("Wrote actual to %s", actualTmp)
 
@@ -302,22 +302,22 @@ func diffFiles(t *testing.T, expectedPath, actual string) error {
 	cmd := exec.Command("diff", "-u", expectedPath, actualTmp)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return xerrors.Errorf("set up stdout pipe from diff failed: %w", err)
+		return fmt.Errorf("set up stdout pipe from diff failed: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		return xerrors.Errorf("start command failed: %w", err)
+		return fmt.Errorf("start command failed: %w", err)
 	}
 
 	diff, err := ioutil.ReadAll(stdout)
 	if err != nil {
-		return xerrors.Errorf("read from diff stdout failed: %w", err)
+		return fmt.Errorf("read from diff stdout failed: %w", err)
 	}
 
 	if err := cmd.Wait(); err != nil {
 		exitErr, ok := err.(*exec.ExitError)
 		if !ok {
-			return xerrors.Errorf("wait for command to finish failed: %w", err)
+			return fmt.Errorf("wait for command to finish failed: %w", err)
 		}
 		t.Logf("Diff exited %s", exitErr)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,10 +2,10 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +45,7 @@ func FindDNSClusterIP(ctx context.Context, c client.Client) (string, error) {
 
 	ip := net.ParseIP(kubernetesService.Spec.ClusterIP)
 	if ip == nil {
-		return "", errors.Errorf("cannot parse kubernetes ClusterIP %q", kubernetesService.Spec.ClusterIP)
+		return "", fmt.Errorf("cannot parse kubernetes ClusterIP %q", kubernetesService.Spec.ClusterIP)
 	}
 
 	// The kubernetes Service ClusterIP is the 1st IP in the Service Subnet.


### PR DESCRIPTION
Go 1.13's `fmt.Errorf()` has wrapping functionality that was achieved using non-std packages prior to that version, which can now be removed.