### PR TITLE
Embed Applier interface in kubectlClient interface 

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/type.go
+++ b/pkg/patterns/declarative/pkg/applier/type.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Applier interface {
-	Applyx(ctx context.Context, namespace string, manifest string, validate bool, extraArgs ...string) error
+	Apply(ctx context.Context, namespace string, manifest string, validate bool, extraArgs ...string) error
 }

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -65,7 +65,7 @@ type Reconciler struct {
 }
 
 type kubectlClient interface {
-	Apply(ctx context.Context, namespace string, manifest string, validate bool, args ...string) error
+	applier.Applier
 }
 
 type DeclarativeObject interface {


### PR DESCRIPTION
Rename Applier interface method from `Applyx` to `Apply` and embed
the Applier interface in the `kubectlClient` interface.