### PR TITLE
Add unit tests for objects.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v0.3.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/prometheus/client_golang v1.7.1
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/tools v0.0.0-20200714190737-9048b464a08d
 	k8s.io/api v0.20.1

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-logr/logr v0.3.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/prometheus/client_golang v1.7.1
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	golang.org/x/tools v0.0.0-20200714190737-9048b464a08d
 	k8s.io/api v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -475,9 +475,11 @@ github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=

--- a/pkg/patterns/declarative/pkg/manifest/objects_test.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects_test.go
@@ -633,3 +633,211 @@ spec:
 		})
 	}
 }
+
+func Test_MutatePodSpec(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputManifest  string
+		expectedObject []*Object
+		error          bool
+		errorString    string
+		fn             func(map[string]interface{}) error
+	}{
+		{
+			name: "normal success pattern",
+			inputManifest: `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: test-app
+spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4`,
+			expectedObject: []*Object{
+				{
+					object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"app": "test-app",
+								},
+								"name": "frontend",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 3,
+								"selector": map[string]interface{}{
+									"matchLabels": map[string]interface{}{
+										"app":  "guestbook",
+										"tier": "frontend",
+									},
+								},
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"app":  "guestbook",
+											"tier": "frontend",
+										},
+									},
+									"spec": map[string]interface{}{
+										"containers": []interface{}{
+											map[string]interface{}{
+												"image": "gcr.io/google-samples/gb-frontend:v4",
+												"name":  "php-redis",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			error: false,
+		},
+		{
+			name: "object has no spec key in template key",
+			inputManifest: `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: test-app
+spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  replicas: 3
+  template: invalid-value`,
+			expectedObject: nil,
+			error:          true,
+			errorString:    "error reading containers: spec.template.spec accessor error: invalid-value is of the type string, expected map[string]interface{}",
+			fn: func(m map[string]interface{}) error {
+				return nil
+			},
+		},
+		{
+			name:           "no manifest",
+			inputManifest:  "",
+			expectedObject: nil,
+			error:          true,
+			errorString:    "pod spec not found",
+			fn: func(m map[string]interface{}) error {
+				return nil
+			},
+		},
+		{
+			name: "object has no containers normal structure",
+			inputManifest: `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: test-app
+spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec: invalid-value`,
+			expectedObject: nil,
+			error:          true,
+			errorString:    "pod spec was not an object",
+			fn: func(m map[string]interface{}) error {
+				return nil
+			},
+		},
+		{
+			name: "mutate function return error",
+			inputManifest: `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: test-app
+spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google-samples/gb-frontend:v4`,
+			expectedObject: nil,
+			error:          true,
+			errorString:    "error occures in mutate function",
+			fn: func(m map[string]interface{}) error {
+				return fmt.Errorf("error occures in mutate function")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			objects, err := ParseObjects(ctx, tt.inputManifest)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if tt.error == false {
+				for _, o := range objects.Items {
+					err = o.MutatePodSpec(func(m map[string]interface{}) error {
+						return nil
+					})
+					actualBytes, _ := o.JSON()
+					actualStr := string(actualBytes)
+
+					expectedBytes, _ := tt.expectedObject[0].JSON()
+					expectedStr := string(expectedBytes)
+
+					if expectedStr != actualStr {
+						t.Fatalf("unexpected result, expected ========\n%v\n\nactual ========\n%v\n", expectedStr, actualStr)
+					}
+				}
+			} else {
+				if tt.inputManifest == "" {
+					o, _ := NewObject(&unstructured.Unstructured{})
+					err = o.MutatePodSpec(tt.fn)
+					assert.EqualError(t, err, tt.errorString)
+				} else {
+					for _, o := range objects.Items {
+						err = o.MutatePodSpec(tt.fn)
+						assert.EqualError(t, err, tt.errorString)
+					}
+				}
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This PR adds some unit tests for `objects.go` because that has some core functions for this framework.
It's good to increase coverage for framework.

This PR doesn't have enough coverage, so I'll update to add more unit tests for `objects.go`.