### PR TITLE
Change assert library with cmp library in test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/google/go-cmp v0.5.5
 	github.com/prometheus/client_golang v1.11.0
-	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/tools v0.1.0
 	k8s.io/api v0.21.1

--- a/pkg/patterns/declarative/watch_test.go
+++ b/pkg/patterns/declarative/watch_test.go
@@ -3,11 +3,11 @@ package declarative
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_uniqueGroupVersionKind(t *testing.T) {
@@ -131,7 +131,9 @@ func Test_uniqueGroupVersionKind(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actualSchema := uniqueGroupVersionKind(tt.inputObjects)
-			assert.Equal(t, tt.expectedSchema, actualSchema)
+			if diff := cmp.Diff(tt.expectedSchema, actualSchema); diff != "" {
+				t.Errorf("schema mismatch (-want +got):\n%s", diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes assert library with `github.com/google/go-cmp/cmp` library.
This is because for fitting to google go style guide, [commented here](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/pull/151#discussion_r598306087).


**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Additional documentation**:
None
