### PR TITLE
Remove directxman12 from OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,6 @@
 
 aliases:
   kubebuilder-admins:
-    - DirectXMan12
     - droot
     - Liujingfang1
     - mengqiy


### PR DESCRIPTION
As per
https://groups.google.com/g/kubebuilder/c/-5hOFa_adr4/m/Sp_Zb755AwAJ,
directxman12 is stepping down.