### PR TITLE
reconcile: apply the manifest before fetching objects from cluster

### DIFF
--- a/examples/guestbook-operator/api/v1alpha1/guestbook_types.go
+++ b/examples/guestbook-operator/api/v1alpha1/guestbook_types.go
@@ -42,6 +42,7 @@ type GuestbookStatus struct {
 // +kubebuilder:object:root=true
 
 // Guestbook is the Schema for the guestbooks API
+// +kubebuilder:subresource:status
 type Guestbook struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/examples/guestbook-operator/config/crd/bases/addons.example.org_guestbooks.yaml
+++ b/examples/guestbook-operator/config/crd/bases/addons.example.org_guestbooks.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: guestbooks.addons.example.org
 spec:
@@ -15,6 +15,8 @@ spec:
     plural: guestbooks
     singular: guestbook
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Guestbook is the Schema for the guestbooks API
@@ -56,6 +58,8 @@ spec:
               type: array
             healthy:
               type: boolean
+            phase:
+              type: string
           required:
           - healthy
           type: object

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
- update the guestbook-operator sample to add status subresources

Signed-off-by: Jeff Luo <jeffluoo@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
Avoid fetching the objects from cluster before applying them

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #162

**Special notes for your reviewer**:

**Additional documentation**:

