### PR TITLE
Unwrap error when checking for not found.

### DIFF
--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -201,7 +201,7 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 	for _, obj := range objects.Items {
 
 		unstruct, err := GetObjectFromCluster(obj, r)
-		if err != nil && !apierrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(errors.Unwrap(err)) {
 			log.WithValues("name", obj.Name).Error(err, "Unable to get resource")
 		}
 		if unstruct != nil {


### PR DESCRIPTION
This has been logging erroneous not found errors since the returned
error wraps the not found error.