### PR TITLE
OWNERS_ALIASES: add estroz

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,3 +9,4 @@ aliases:
     - monopole
     - pmorie
     - pwittrock
+    - estroz


### PR DESCRIPTION
To help shepherd in kubebuilder-related PR's like #160 (mostly k8s version bumps).