### PR TITLE
Re-use the RESTMapper from the ctrl.Manager in the dynamic watcher

### DIFF
--- a/docs/addon/walkthrough/README.md
+++ b/docs/addon/walkthrough/README.md
@@ -176,7 +176,7 @@ func (r *GuestbookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Watch for changes to deployed objects
-	_, err = declarative.WatchAll(mgr.GetConfig(), c, r, r.watchLabels)
+	_, err = declarative.WatchChildren(declarative.WatchChildrenOptions{Manager: mgr, Controller: c, Reconciler: r, LabelMaker: r.watchLabels})
 	if err != nil {
 		return err
 	}

--- a/examples/guestbook-operator/controllers/guestbook_controller.go
+++ b/examples/guestbook-operator/controllers/guestbook_controller.go
@@ -79,7 +79,7 @@ func (r *GuestbookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Watch for changes to deployed objects
-	_, err = declarative.WatchAll(mgr.GetConfig(), c, r, r.watchLabels)
+	_, err = declarative.WatchChildren(declarative.WatchChildrenOptions{Manager: mgr, Controller: c, Reconciler: r, LabelMaker: r.watchLabels})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Though this is a breaking change, reusing the RESTMapper avoids repeated discovery.
    
Also mark the watch functions as deprecated to support a future move to an internal package.
