### PR TITLE
Fix namespace setting with direct applier

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -2,48 +2,71 @@ package applier
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/apply"
 	cmdDelete "k8s.io/kubectl/pkg/cmd/delete"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 type DirectApplier struct {
-	a apply.ApplyOptions
 }
+
+var _ Applier = &DirectApplier{}
 
 func NewDirectApplier() *DirectApplier {
 	return &DirectApplier{}
 }
 
-func (d *DirectApplier) Apply(ctx context.Context,
-	namespace string,
-	manifest string,
-	validate bool,
-	extraArgs ...string,
-) error {
+func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 	ioStreams := genericclioptions.IOStreams{
 		In:     os.Stdin,
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,
 	}
-	restClient := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
-	ioReader := strings.NewReader(manifest)
+	ioReader := strings.NewReader(opt.Manifest)
 
-	b := resource.NewBuilder(restClient)
+	restClientGetter := &staticRESTClientGetter{
+		RESTMapper: opt.RESTMapper,
+		RESTConfig: opt.RESTConfig,
+	}
+	b := resource.NewBuilder(restClientGetter)
+
+	if opt.Validate {
+		// This potentially causes redundant work, but validation isn't the common path
+		v, err := cmdutil.NewFactory(&genericclioptions.ConfigFlags{}).Validator(true)
+		if err != nil {
+			return err
+		}
+		b.Schema(v)
+	}
+
 	res := b.Unstructured().Stream(ioReader, "manifestString").Do()
 	infos, err := res.Infos()
 	if err != nil {
 		return err
 	}
 
+	// Populate the namespace on any namespace-scoped objects
+	if opt.Namespace != "" {
+		visitor := resource.SetNamespace(opt.Namespace)
+		for _, info := range infos {
+			if err := info.Visit(visitor); err != nil {
+				return fmt.Errorf("error from SetNamespace: %w", err)
+			}
+		}
+	}
+
 	applyOpts := apply.NewApplyOptions(ioStreams)
-	applyOpts.Namespace = namespace
+	applyOpts.Namespace = opt.Namespace
 	applyOpts.SetObjects(infos)
 	applyOpts.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
 		applyOpts.PrintFlags.NamePrintFlags.Operation = operation
@@ -55,4 +78,32 @@ func (d *DirectApplier) Apply(ctx context.Context,
 	}
 
 	return applyOpts.Run()
+}
+
+// staticRESTClientGetter returns a fixed RESTClient
+type staticRESTClientGetter struct {
+	RESTConfig      *rest.Config
+	DiscoveryClient discovery.CachedDiscoveryInterface
+	RESTMapper      meta.RESTMapper
+}
+
+var _ resource.RESTClientGetter = &staticRESTClientGetter{}
+
+func (s *staticRESTClientGetter) ToRESTConfig() (*rest.Config, error) {
+	if s.RESTConfig == nil {
+		return nil, fmt.Errorf("RESTConfig not set")
+	}
+	return s.RESTConfig, nil
+}
+func (s *staticRESTClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	if s.DiscoveryClient == nil {
+		return nil, fmt.Errorf("DiscoveryClient not set")
+	}
+	return s.DiscoveryClient, nil
+}
+func (s *staticRESTClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	if s.RESTMapper == nil {
+		return nil, fmt.Errorf("RESTMapper not set")
+	}
+	return s.RESTMapper, nil
 }

--- a/pkg/patterns/declarative/pkg/applier/exec_test.go
+++ b/pkg/patterns/declarative/pkg/applier/exec_test.go
@@ -85,7 +85,13 @@ func TestKubectlApply(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cs := collector{Error: test.err}
 			kubectl := &ExecKubectl{cmdSite: &cs}
-			err := kubectl.Apply(context.Background(), test.namespace, test.manifest, test.validate, test.args...)
+			opts := ApplierOptions{
+				Namespace: test.namespace,
+				Manifest:  test.manifest,
+				Validate:  test.validate,
+				ExtraArgs: test.args,
+			}
+			err := kubectl.Apply(context.Background(), opts)
 
 			if test.err != nil && err == nil {
 				t.Error("expected error to occur")

--- a/pkg/patterns/declarative/pkg/applier/type.go
+++ b/pkg/patterns/declarative/pkg/applier/type.go
@@ -2,8 +2,21 @@ package applier
 
 import (
 	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
 )
 
 type Applier interface {
-	Apply(ctx context.Context, namespace string, manifest string, validate bool, extraArgs ...string) error
+	Apply(ctx context.Context, options ApplierOptions) error
+}
+
+type ApplierOptions struct {
+	Manifest string
+
+	RESTConfig *rest.Config
+	RESTMapper meta.RESTMapper
+	Namespace  string
+	Validate   bool
+	ExtraArgs  []string
 }


### PR DESCRIPTION
The direct-applier was not setting the namespace correctly; we reuse
the SetNamespace visitor to do so.
