### PR TITLE
Update go1.16 in github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
           stable: true
 
       - run: |
@@ -39,7 +39,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
           stable: true
 
       - run: |
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.15
+        go-version: 1.16
     - name: Install latest version of Kind
       run: |
         GO111MODULE=on go get sigs.k8s.io/kind


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates golang version to 1.16 in github workflow files.

GitHub workflow job `CI / verify-gomod (pull_request)` fails in #169. 
[Failure detail log here](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/pull/169/checks?check_run_id=3503792196)
That PR update go version to v1.16 in go.mod, but specified version in workflow is set to [v1.15](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/1f796d48dfcd38bf1a74bba3dd60f80bf094a995/.github/workflows/main.yml#L42).

Github workflow job failure in #169 will be fixed once this PR merged, I think.
