### PR TITLE
Update walkthrough docs to fit latest code

### DIFF
--- a/docs/addon/walkthrough/README.md
+++ b/docs/addon/walkthrough/README.md
@@ -147,7 +147,6 @@ func (r *GuestbookReconciler) setupReconciler(mgr ctrl.Manager) error {
 		declarative.WithOwner(declarative.SourceAsOwner),
 		declarative.WithLabels(r.watchLabels),
 		declarative.WithStatus(status.NewBasic(mgr.GetClient())),
-		declarative.WithPreserveNamespace(),
 		declarative.WithApplyPrune(),
 		declarative.WithReconcileMetrics(0, nil),
 	)
@@ -233,6 +232,8 @@ kubectl get crds guestbooks.addons.example.org
 ```
 
 2) Create a guestbook CR:
+
+Remove `spec.foo` key in `config/samples/addons_v1alpha1_guestbook.yaml` if exists.
 
 ```bash
 kubectl apply -n kube-system -f config/samples/addons_v1alpha1_guestbook.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates walkthrough docs to fit latest code.
Recently, apply logic in kubebuilder-declarative-pattern is updated by #173,
that why we need to update documentations.

And I added that removing `spec.foo` key in `config/samples/addons_v1alpha1_guestbook.yaml`.

**Which issue(s) this PR fixes**:
Related to #176
