### PR TITLE
Fit example guestbook-operator to walkthrough document

### DIFF
--- a/examples/guestbook-operator/config/crd/bases/addons.example.org_guestbooks.yaml
+++ b/examples/guestbook-operator/config/crd/bases/addons.example.org_guestbooks.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,54 +15,49 @@ spec:
     plural: guestbooks
     singular: guestbook
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: Guestbook is the Schema for the guestbooks API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: GuestbookSpec defines the desired state of Guestbook
-          properties:
-            channel:
-              description: 'Channel specifies a channel that can be used to resolve
-                a specific addon, eg: stable It will be ignored if Version is specified'
-              type: string
-            patches:
-              items:
-                type: object
-              type: array
-            version:
-              description: Version specifies the exact addon version to be deployed,
-                eg 1.2.3 It should not be specified if Channel is specified
-              type: string
-          type: object
-        status:
-          description: GuestbookStatus defines the observed state of Guestbook
-          properties:
-            errors:
-              items:
-                type: string
-              type: array
-            healthy:
-              type: boolean
-          required:
-          - healthy
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Guestbook is the Schema for the guestbooks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GuestbookSpec defines the desired state of Guestbook
+            properties:
+              channel:
+                description: 'Channel specifies a channel that can be used to resolve a specific addon, eg: stable It will be ignored if Version is specified'
+                type: string
+              patches:
+                items:
+                  type: object
+                type: array
+              version:
+                description: Version specifies the exact addon version to be deployed, eg 1.2.3 It should not be specified if Channel is specified
+                type: string
+            type: object
+          status:
+            description: GuestbookStatus defines the observed state of Guestbook
+            properties:
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              phase:
+                type: string
+            required:
+            - healthy
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/examples/guestbook-operator/config/samples/addons_v1alpha1_guestbook.yaml
+++ b/examples/guestbook-operator/config/samples/addons_v1alpha1_guestbook.yaml
@@ -3,5 +3,3 @@ kind: Guestbook
 metadata:
   name: guestbook-sample
 spec:
-  # Add fields here
-  foo: bar

--- a/examples/guestbook-operator/controllers/guestbook_controller.go
+++ b/examples/guestbook-operator/controllers/guestbook_controller.go
@@ -52,7 +52,6 @@ func (r *GuestbookReconciler) setupReconciler(mgr ctrl.Manager) error {
 		declarative.WithOwner(declarative.SourceAsOwner),
 		declarative.WithLabels(r.watchLabels),
 		declarative.WithStatus(status.NewBasic(mgr.GetClient())),
-		declarative.WithPreserveNamespace(),
 		declarative.WithApplyPrune(),
 		declarative.WithObjectTransform(addon.ApplyPatches),
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates guestbook-operator codes to follow [walkthrough document](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/docs/addon/walkthrough/README.md).
Recently walkthrough document is updated by #179.

