### PR TITLE
Skip setting owner refs for objects that don't support it

### DIFF
--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -493,9 +493,12 @@ func (r *Reconciler) injectOwnerRef(ctx context.Context, instance DeclarativeObj
 			continue
 		}
 
-		// TODO, error/skip if:
-		// - owner is namespaced and o is not
-		// - owner is in a different namespace than o
+		if owner.GetNamespace() != "" && owner.GetNamespace() != o.Namespace {
+			// a namespaced object can only own objects within the same namespace, not objects in other namespaces or cluster-scoped objects
+			// for any other combination, skip setting owner reference here, to allow declarative.SourceAsOwner to be used for the
+			// subset of objects that make up a supported combination
+			continue
+		}
 
 		ownerRefs := []interface{}{
 			map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this fix, a declarative controller using `declarative.WithOwner(declarative.SourceAsOwner)` will end up in an infinite reconciliation loop if any of the manifests in the package do not support having the declarative object as its owner.

For example, consider a _namespaced_ declarative object `foo/foo` of type `Foo`, installing a package that adds a few objects (say, two `Bar`s) in the same namespace plus another object (say, a `Baz`) in a fixed namespace `qux`. With the old behavior of this reconciler, the following happens:

1. The reconciler creates all objects in the package, setting owner references to an object with the same group, version, kind and name as the declarative object, and the same namespace as each respective object from the package. In other words, we get two `Bar`s in `foo` owned by `foo/foo`, and a `Baz` in `qux` owned by `qux/foo`.

2. Since `qux/foo` does not exist, the API server decides that it must have been deleted, and that means `qux/baz` should also be deleted (its owner no longer exists).

3. The reconciler is notified, and determines that `qux/baz` is missing, re-adding it again with an owner reference to `qux/foo`.

4. Go back to step 2.

With the change in this PR, the reconciler will instead skip setting an owner reference on `qux/foo`, avoiding the infinite loop at the cost of `qux/foo` now being a "dangling" object; if/when the declarative object `foo/foo` is deleted, `qux/foo` will be left untouched in the cluster.

**Which issue(s) this PR fixes**:
Fixes #176