### PR TITLE
Use io and os in favor of ioutil

### DIFF
--- a/hack/smoketest.go
+++ b/hack/smoketest.go
@@ -29,7 +29,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -450,7 +449,7 @@ func (h *RealTestHarness) KubectlApply(p string) {
 	}
 
 	if stat.IsDir() {
-		files, err := ioutil.ReadDir(p)
+		files, err := os.ReadDir(p)
 		if err != nil {
 			h.Fatalf("error reading directory %s: %v", p, err)
 		}
@@ -483,7 +482,7 @@ func (h *RealTestHarness) KubectlDelete(p string) {
 }
 
 func (h *RealTestHarness) kubectlApplyFile(p string) {
-	b, err := ioutil.ReadFile(p)
+	b, err := os.ReadFile(p)
 	if err != nil {
 		h.Fatalf("error reading file %s: %v", p, err)
 	}

--- a/pkg/patterns/addon/pkg/loaders/git.go
+++ b/pkg/patterns/addon/pkg/loaders/git.go
@@ -3,7 +3,6 @@ package loaders
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -115,7 +114,7 @@ func (r *GitRepository) readURL(url string) ([]byte, error) {
 		}
 	}
 
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +188,7 @@ func getAuthMethod() (transport.AuthMethod, error) {
 	if _, err := os.Stat(sshFile); os.IsNotExist(err) {
 		return nil, nil
 	}
-	sshBytes, err := ioutil.ReadFile(sshFile)
+	sshBytes, err := os.ReadFile(sshFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/patterns/addon/pkg/loaders/http.go
+++ b/pkg/patterns/addon/pkg/loaders/http.go
@@ -19,7 +19,7 @@ package loaders
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -113,7 +113,7 @@ func (r *HTTPRepository) readURL(url string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error fetching %q: %v", url, err)
 	}
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response for %q: %v", url, err)
 	}

--- a/pkg/patterns/addon/pkg/loaders/types.go
+++ b/pkg/patterns/addon/pkg/loaders/types.go
@@ -19,7 +19,7 @@ package loaders
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -97,7 +97,7 @@ func (r *FSRepository) LoadChannel(ctx context.Context, name string) (*Channel, 
 	log.WithValues("channel", name).WithValues("base", r.basedir).Info("loading channel")
 
 	p := filepath.Join(r.basedir, name)
-	b, err := ioutil.ReadFile(p)
+	b, err := os.ReadFile(p)
 	if err != nil {
 		log.WithValues("path", p).Error(err, "error reading channel")
 		return nil, fmt.Errorf("error reading channel %s: %v", p, err)
@@ -124,7 +124,7 @@ func (r *FSRepository) LoadManifest(ctx context.Context, packageName string, id 
 	log.WithValues("package", packageName).Info("loading package")
 
 	dirPath := filepath.Join(r.basedir, "packages", packageName, id)
-	filesPath, err := ioutil.ReadDir(dirPath)
+	filesPath, err := os.ReadDir(dirPath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading directory %s: %v", dirPath, err)
 	}
@@ -136,7 +136,7 @@ func (r *FSRepository) LoadManifest(ctx context.Context, packageName string, id 
 		}
 
 		filePath := filepath.Join(dirPath, p.Name())
-		b, err := ioutil.ReadFile(filePath)
+		b, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, fmt.Errorf("error reading file %s: %v", filePath, err)
 		}

--- a/pkg/patterns/declarative/metrics_test.go
+++ b/pkg/patterns/declarative/metrics_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -531,7 +531,7 @@ func TestAddIfNotPresent(t *testing.T) {
 					t.Error(err)
 				}
 
-				tmpManifests, err := ioutil.TempFile(t.TempDir(), "tmp-manifests-*.yaml")
+				tmpManifests, err := os.CreateTemp(t.TempDir(), "tmp-manifests-*.yaml")
 				if err != nil {
 					t.Error(err)
 				}

--- a/pkg/patterns/declarative/pkg/applier/exec_test.go
+++ b/pkg/patterns/declarative/pkg/applier/exec_test.go
@@ -19,12 +19,10 @@ package applier
 import (
 	"context"
 	"errors"
-	"testing"
-
-	"io/ioutil"
-	"reflect"
-
+	"io"
 	"os/exec"
+	"reflect"
+	"testing"
 )
 
 // collector is a commandSite implementation that stubs cmd.Run() calls for tests
@@ -108,7 +106,7 @@ func TestKubectlApply(t *testing.T) {
 				t.Errorf("argument mistmatch, expected: %v, got: %v", test.expectArgs, cmd.Args)
 			}
 
-			stdinBytes, err := ioutil.ReadAll(cmd.Stdin)
+			stdinBytes, err := io.ReadAll(cmd.Stdin)
 			if stdin := string(stdinBytes); stdin != test.manifest {
 				t.Errorf("manifest mismatch, expected: %v, got: %v", test.manifest, stdin)
 			}

--- a/pkg/test/golden/validator.go
+++ b/pkg/test/golden/validator.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -146,7 +146,7 @@ func (v *validator) Validate(r declarative.Reconciler) {
 		basedir = v.TestDir
 	}
 
-	files, err := ioutil.ReadDir(basedir)
+	files, err := os.ReadDir(basedir)
 	if err != nil {
 		t.Fatalf("error reading dir %s: %v", basedir, err)
 	}
@@ -175,7 +175,7 @@ func (v *validator) Validate(r declarative.Reconciler) {
 			continue
 		}
 
-		b, err := ioutil.ReadFile(p)
+		b, err := os.ReadFile(p)
 		if err != nil {
 			t.Errorf("error reading file %s: %v", p, err)
 			continue
@@ -247,7 +247,7 @@ func (v *validator) Validate(r declarative.Reconciler) {
 		expectedPath := strings.Replace(p, ".in.yaml", ".out.yaml", -1)
 		var expectedYAML string
 		{
-			b, err := ioutil.ReadFile(expectedPath)
+			b, err := os.ReadFile(expectedPath)
 			if err != nil {
 				t.Errorf("error reading file %s: %v", expectedPath, err)
 				continue
@@ -258,7 +258,7 @@ func (v *validator) Validate(r declarative.Reconciler) {
 		if actualYAML != expectedYAML {
 			if os.Getenv("HACK_AUTOFIX_EXPECTED_OUTPUT") != "" {
 				t.Logf("HACK_AUTOFIX_EXPECTED_OUTPUT is set; replacing expected output in %s", expectedPath)
-				if err := ioutil.WriteFile(expectedPath, []byte(actualYAML), 0644); err != nil {
+				if err := os.WriteFile(expectedPath, []byte(actualYAML), 0644); err != nil {
 					t.Fatalf("error writing expected output to %s: %v", expectedPath, err)
 				}
 				continue
@@ -279,7 +279,7 @@ func (v *validator) Validate(r declarative.Reconciler) {
 func diffFiles(t *testing.T, expectedPath, actual string) error {
 	t.Helper()
 	writeTmp := func(content string) (string, error) {
-		tmp, err := ioutil.TempFile("", "*.yaml")
+		tmp, err := os.CreateTemp("", "*.yaml")
 		if err != nil {
 			return "", err
 		}
@@ -309,7 +309,7 @@ func diffFiles(t *testing.T, expectedPath, actual string) error {
 		return fmt.Errorf("start command failed: %w", err)
 	}
 
-	diff, err := ioutil.ReadAll(stdout)
+	diff, err := io.ReadAll(stdout)
 	if err != nil {
 		return fmt.Errorf("read from diff stdout failed: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
Cleanup deprecated ioutil and use io and os instead

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

