### PR TITLE
Implement a fake status client for testing

### DIFF
--- a/pkg/test/mocks/client.go
+++ b/pkg/test/mocks/client.go
@@ -88,7 +88,7 @@ func (FakeClient) Update(ctx context.Context, obj client.Object, opts ...client.
 }
 
 func (FakeClient) Status() client.StatusWriter {
-	panic("not implemented")
+	return FakeStatusClient{}
 }
 
 func (FakeClient) RESTMapper() meta.RESTMapper {
@@ -106,4 +106,14 @@ func getGVRFromObject(obj client.Object, scheme *runtime.Scheme) (schema.GroupVe
 	}
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 	return gvr, nil
+}
+
+type FakeStatusClient struct{}
+
+func (FakeStatusClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return nil
+}
+
+func (FakeStatusClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a `FakeStatusClient` with noop implementations of `Update` and `Patch`, to enable doing things like `client.Status().Update(...)` in methods being tested.

I don't know if there was any special reason this was not already in place, other than "it hadn't been needed yet" - if there are any special considerations that need to be taken care of when updating status, this PR might not be good enough. But given that `FakeClient.Update` and similar methods also just `return nil`, this should probably be OK for most use cases.
