### PR TITLE
refactory updating status mechanism and add custom private registry logic support

### DIFF
--- a/pkg/patterns/addon/pkg/status/aggregate.go
+++ b/pkg/patterns/addon/pkg/status/aggregate.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
@@ -44,7 +45,7 @@ type aggregator struct {
 	client client.Client
 }
 
-func (a *aggregator) Reconciled(ctx context.Context, src declarative.DeclarativeObject, objs *manifest.Objects) error {
+func (a *aggregator) Reconciled(ctx context.Context, src declarative.DeclarativeObject, objs *manifest.Objects, _ error) error {
 	log := log.Log
 
 	statusHealthy := true

--- a/pkg/patterns/addon/pkg/status/kstatus.go
+++ b/pkg/patterns/addon/pkg/status/kstatus.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/utils"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
@@ -22,7 +23,7 @@ func NewKstatusAgregator(c client.Client, reconciler *declarative.Reconciler) *k
 }
 
 func (k *kstatusAggregator) Reconciled(ctx context.Context, src declarative.DeclarativeObject,
-	objs *manifest.Objects) error {
+	objs *manifest.Objects, _ error) error {
 	log := log.Log
 
 	statusMap := make(map[status.Status]bool)

--- a/pkg/patterns/declarative/image.go
+++ b/pkg/patterns/declarative/image.go
@@ -22,17 +22,27 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
 // ImageRegistryTransform modifies all Pods to use registry for the image source and adds the imagePullSecret
 func ImageRegistryTransform(registry, imagePullSecret string) ObjectTransform {
 	return func(c context.Context, o DeclarativeObject, m *manifest.Objects) error {
-		return applyImageRegistry(c, o, m, registry, imagePullSecret)
+		return applyImageRegistry(c, o, m, registry, imagePullSecret, applyPrivateRegistryToImage)
 	}
 }
 
-func applyImageRegistry(ctx context.Context, operatorObject DeclarativeObject, manifest *manifest.Objects, registry, secret string) error {
+type ImageFunc func(registry, image string) string
+
+// PrivateRegistryTransform modifies all Pods to use registry for the image source and adds the imagePullSecret
+func PrivateRegistryTransform(registry, imagePullSecret string, imageFunc ImageFunc) ObjectTransform {
+	return func(c context.Context, o DeclarativeObject, m *manifest.Objects) error {
+		return applyImageRegistry(c, o, m, registry, imagePullSecret, imageFunc)
+	}
+}
+
+func applyImageRegistry(ctx context.Context, operatorObject DeclarativeObject, manifest *manifest.Objects, registry, secret string, imageFunc ImageFunc) error {
 	log := log.Log
 	if registry == "" && secret == "" {
 		return nil
@@ -43,7 +53,7 @@ func applyImageRegistry(ctx context.Context, operatorObject DeclarativeObject, m
 			manifestItem.Kind == "CronJob" {
 			if registry != "" {
 				log.WithValues("manifest", manifestItem).WithValues("registry", registry).V(1).Info("applying image registory to manifest")
-				if err := manifestItem.MutateContainers(applyPrivateRegistryToContainer(registry)); err != nil {
+				if err := manifestItem.MutateContainers(applyPrivateRegistryToContainer(registry, imageFunc)); err != nil {
 					return fmt.Errorf("error applying private registry: %v", err)
 				}
 			}
@@ -68,13 +78,19 @@ func applyImagePullSecret(secret string) func(map[string]interface{}) error {
 	}
 }
 
-func applyPrivateRegistryToContainer(registry string) func(map[string]interface{}) error {
+func applyPrivateRegistryToContainer(registry string, imageFunc ImageFunc) func(map[string]interface{}) error {
 	return func(container map[string]interface{}) error {
 		image, _, err := unstructured.NestedString(container, "image")
 		if err != nil {
 			return fmt.Errorf("error reading container image: %v", err)
 		}
-		container["image"] = applyPrivateRegistryToImage(registry, image)
+
+		// imageFunc can not be nil
+		if imageFunc == nil {
+			imageFunc = applyPrivateRegistryToImage
+		}
+
+		container["image"] = imageFunc(registry, image)
 		return nil
 	}
 }

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -39,10 +39,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/applier"
-	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/krusty"
+
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/applier"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
 var _ reconcile.Reconciler = &Reconciler{}
@@ -71,6 +72,15 @@ type kubectlClient interface {
 type DeclarativeObject interface {
 	runtime.Object
 	metav1.Object
+}
+
+type ErrorResult struct {
+	Result reconcile.Result
+	Err    error
+}
+
+func (e *ErrorResult) Error() string {
+	return e.Err.Error()
 }
 
 // For mocking
@@ -118,6 +128,7 @@ func (r *Reconciler) Init(mgr manager.Manager, prototype DeclarativeObject, opts
 
 // +rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, err error) {
+	var objects *manifest.Objects
 	log := log.Log
 	defer r.collectMetrics(request, result, err)
 
@@ -134,6 +145,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	// status.Reconciled should catch all error
+	defer func() {
+		// data is Error
+		resultErr, ok := err.(*ErrorResult)
+		if ok {
+			result = resultErr.Result
+			err = resultErr.Err
+		}
+
+		if r.options.status != nil {
+			if err = r.options.status.Reconciled(ctx, instance, objects, err); err != nil {
+				log.Error(err, "failed to reconcile status")
+			}
+		}
+	}()
+
 	if r.options.status != nil {
 		if err := r.options.status.Preflight(ctx, instance); err != nil {
 			log.Error(err, "preflight check failed, not reconciling")
@@ -141,10 +168,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	return r.reconcileExists(ctx, request.NamespacedName, instance)
+	objects, err = r.reconcileExists(ctx, request.NamespacedName, instance)
+
+	return result, err
 }
 
-func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedName, instance DeclarativeObject) (reconcile.Result, error) {
+func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedName, instance DeclarativeObject) (*manifest.Objects, error) {
 	log := log.Log
 	log.WithValues("object", name.String()).Info("reconciling")
 
@@ -156,7 +185,7 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 	objects, err := r.BuildDeploymentObjectsWithFs(ctx, name, instance, fs)
 	if err != nil {
 		log.Error(err, "building deployment objects")
-		return reconcile.Result{}, fmt.Errorf("error building deployment objects: %v", err)
+		return nil, fmt.Errorf("error building deployment objects: %v", err)
 	}
 	log.WithValues("objects", fmt.Sprintf("%d", len(objects.Items))).Info("built deployment objects")
 
@@ -166,35 +195,27 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 			if !isValidVersion {
 				// r.client isn't exported so can't be updated in version check function
 				if err := r.client.Status().Update(ctx, instance); err != nil {
-					return reconcile.Result{}, err
+					return objects, err
 				}
 				r.recorder.Event(instance, "Warning", "Failed version check", err.Error())
 				log.Error(err, "Version check failed, not reconciling")
-				return reconcile.Result{}, nil
+				return objects, nil
 			}
 			log.Error(err, "Version check failed, trying to reconcile")
-			return reconcile.Result{}, err
+			return objects, err
 		}
 	}
-
-	defer func() {
-		if r.options.status != nil {
-			if err := r.options.status.Reconciled(ctx, instance, objects); err != nil {
-				log.Error(err, "failed to reconcile status")
-			}
-		}
-	}()
 
 	objects, err = parseListKind(objects)
 
 	if err != nil {
 		log.Error(err, "Parsing list kind")
-		return reconcile.Result{}, fmt.Errorf("error parsing list kind: %v", err)
+		return objects, fmt.Errorf("error parsing list kind: %v", err)
 	}
 
 	err = r.injectOwnerRef(ctx, instance, objects)
 	if err != nil {
-		return reconcile.Result{}, err
+		return objects, err
 	}
 
 	var newItems []*manifest.Object
@@ -221,7 +242,7 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 	m, err := objects.JSONManifest()
 	if err != nil {
 		log.Error(err, "creating final manifest")
-		return reconcile.Result{}, fmt.Errorf("error creating manifest: %v", err)
+		return objects, fmt.Errorf("error creating manifest: %v", err)
 	}
 	manifestStr = m
 
@@ -267,16 +288,16 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 
 	if err := r.kubectl.Apply(ctx, applyOpt); err != nil {
 		log.Error(err, "applying manifest")
-		return reconcile.Result{}, fmt.Errorf("error applying manifest: %v", err)
+		return objects, fmt.Errorf("error applying manifest: %v", err)
 	}
 
 	if r.options.sink != nil {
 		if err := r.options.sink.Notify(ctx, instance, objects); err != nil {
 			log.Error(err, "notifying sink")
-			return reconcile.Result{}, err
+			return objects, err
 		}
 	}
-	return reconcile.Result{}, nil
+	return objects, nil
 }
 
 // BuildDeploymentObjects performs all manifest operations to build a final set of objects for deployment

--- a/pkg/patterns/declarative/status.go
+++ b/pkg/patterns/declarative/status.go
@@ -33,7 +33,7 @@ type Reconciled interface {
 	// Reconciled is triggered when Reconciliation has occured.
 	// The caller is encouraged to determine and surface the health of the reconcilation
 	// on the DeclarativeObject.
-	Reconciled(context.Context, DeclarativeObject, *manifest.Objects) error
+	Reconciled(context.Context, DeclarativeObject, *manifest.Objects, error) error
 }
 
 type Preflight interface {
@@ -57,9 +57,9 @@ type StatusBuilder struct {
 	VersionCheckImpl VersionCheck
 }
 
-func (s *StatusBuilder) Reconciled(ctx context.Context, src DeclarativeObject, objs *manifest.Objects) error {
+func (s *StatusBuilder) Reconciled(ctx context.Context, src DeclarativeObject, objs *manifest.Objects, err error) error {
 	if s.ReconciledImpl != nil {
-		return s.ReconciledImpl.Reconciled(ctx, src, objs)
+		return s.ReconciledImpl.Reconciled(ctx, src, objs, err)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This Pull Request includes two features:
1. refractory mechanism of updating status:
    a. allow status `Reconciled` method known if `error` happened, so that user could be able to submit an error to CR status field or launch an Event;
    b. maybe it's related with #190 
2. add the ability to custom private registry logic:
    for now, It always replaces the registry endpoint with a namespace (`placeholder/ns/image_name` --> `private_registry/image_name` ). But I want preserve namespace unchanged, (`placeholder/ns/image_name` --> `private_registry/ns/image_name` ). Compare with adding an new `ImageRegistryTransform`, leave `applyPrivateRegistryToImage` func customiable is a better way?


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

