### PR TITLE
Propagate applyOpts extraArgs

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -66,6 +66,20 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 	}
 
 	applyOpts := apply.NewApplyOptions(ioStreams)
+
+	for i, arg := range opt.ExtraArgs {
+		switch arg {
+		case "--force":
+			applyOpts.ForceConflicts = true
+		case "--prune":
+			applyOpts.Prune = true
+		case "--selector":
+			applyOpts.Selector = opt.ExtraArgs[i + 1]
+		default:
+			continue
+		}
+	}
+
 	applyOpts.Namespace = opt.Namespace
 	applyOpts.SetObjects(infos)
 	applyOpts.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

A not so pretty solution for https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/issues/201, more like a temporary workaround.

I think it would be nicer to use `ApplyOptions` directly instead of the internal `ApplierOptions` type, but this would break compatibility with ExecApplier.

**Which issue(s) this PR fixes**:
Fixes [#201](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/issues/201)


