### PR TITLE
refactor: Use strategic merge patch

### DIFF
--- a/pkg/patterns/declarative/pkg/manifest/patch.go
+++ b/pkg/patterns/declarative/pkg/manifest/patch.go
@@ -90,17 +90,24 @@ func apply(base *unstructured.Unstructured, patches []*unstructured.Unstructured
 			return nil, err
 		default:
 			// Use Strategic-Merge-Patch to handle types w/ schema
-			// TODO: Change this to use the new Merge package.
 			// Store the name of the base object, because this name may have been munged.
 			// Apply this name to the patched object.
-			lookupPatchMeta, err := strategicpatch.NewPatchMetaFromStruct(versionedObj)
+			baseBytes, err := merged.MarshalJSON()
 			if err != nil {
 				return nil, err
 			}
-			merged.Object, err = strategicpatch.StrategicMergeMapPatchUsingLookupPatchMeta(
-				merged.Object,
-				p.Object,
-				lookupPatchMeta)
+			patchBytes, err := p.MarshalJSON()
+			if err != nil {
+				return nil, err
+			}
+			mergedBytes, err := strategicpatch.StrategicMergePatch(
+				baseBytes,
+				patchBytes,
+				versionedObj)
+			if err != nil {
+				return nil, err
+			}
+			err = merged.UnmarshalJSON(mergedBytes)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Store the name of the base object, because this name may have been munged.
Apply this name to the patched object.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:


**Additional documentation**:

[StrategicMergePatch](https://github.com/kubernetes/apimachinery/blob/df993592a122931b8aac4db57689e09458a2332c/pkg/util/strategicpatch/patch.go#L812).