### PR TITLE
Introduce setters for name and namespace

### DIFF
--- a/docs/releases/release-0.12.md
+++ b/docs/releases/release-0.12.md
@@ -1,3 +1,7 @@
 # Release notes for 0.12 release
 
 Note: the 0.12 release is pending.  This serves to accumulate breaking/important changes prior to release.
+
+* Name and Namespace are not longer exported by manifest.Object; use GetName() and GetNamespace() instead.
+  This change allows setting the values.
+  It also makes `declarative.Object` more similar to `unstructured.Unstructured`, which we model after.

--- a/docs/releases/release-0.12.md
+++ b/docs/releases/release-0.12.md
@@ -1,0 +1,3 @@
+# Release notes for 0.12 release
+
+Note: the 0.12 release is pending.  This serves to accumulate breaking/important changes prior to release.

--- a/pkg/patterns/addon/pkg/status/aggregate.go
+++ b/pkg/patterns/addon/pkg/status/aggregate.go
@@ -55,8 +55,8 @@ func (a *aggregator) Reconciled(ctx context.Context, src declarative.Declarative
 		gk := o.Group + "/" + o.Kind
 		healthy := true
 		objKey := client.ObjectKey{
-			Name:      o.Name,
-			Namespace: o.Namespace,
+			Name:      o.GetName(),
+			Namespace: o.GetNamespace(),
 		}
 		// If the namespace isn't set on the object, we would want to use the namespace of src
 		if objKey.Namespace == "" {

--- a/pkg/patterns/addon/pkg/status/kstatus.go
+++ b/pkg/patterns/addon/pkg/status/kstatus.go
@@ -31,18 +31,18 @@ func (k *kstatusAggregator) Reconciled(ctx context.Context, src declarative.Decl
 
 		unstruct, err := declarative.GetObjectFromCluster(object, k.reconciler)
 		if err != nil {
-			log.WithValues("object", object.Kind+"/"+object.Name).Error(err, "Unable to get status of object")
+			log.WithValues("object", object.Kind+"/"+object.GetName()).Error(err, "Unable to get status of object")
 			return err
 		}
 
 		res, err := status.Compute(unstruct)
 		if err != nil {
-			log.WithValues("kind", object.Kind).WithValues("name", object.Name).WithValues("status", res.Status).WithValues(
+			log.WithValues("kind", object.Kind).WithValues("name", object.GetName()).WithValues("status", res.Status).WithValues(
 				"message", res.Message).Info("Got status of resource:")
 			statusMap[status.NotFoundStatus] = true
 		}
 		if res != nil {
-			log.WithValues("kind", object.Kind).WithValues("name", object.Name).WithValues("status", res.Status).WithValues("message", res.Message).Info("Got status of resource:")
+			log.WithValues("kind", object.Kind).WithValues("name", object.GetName()).WithValues("status", res.Status).WithValues("message", res.Message).Info("Got status of resource:")
 			statusMap[res.Status] = true
 		}
 	}

--- a/pkg/patterns/addon/pkg/status/version.go
+++ b/pkg/patterns/addon/pkg/status/version.go
@@ -77,7 +77,7 @@ func (p *versionCheck) VersionCheck(
 	if !reflect.DeepEqual(status, currentStatus) {
 		err := utils.SetCommonStatus(src, status)
 		if err != nil {
-			log.Error(err, "unable to updating status")
+			log.Error(err, "unable to update status")
 		}
 	}
 

--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -74,7 +74,7 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 		case "--prune":
 			applyOpts.Prune = true
 		case "--selector":
-			applyOpts.Selector = opt.ExtraArgs[i + 1]
+			applyOpts.Selector = opt.ExtraArgs[i+1]
 		default:
 			continue
 		}

--- a/pkg/patterns/declarative/pkg/manifest/objects.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects.go
@@ -40,9 +40,10 @@ type Object struct {
 	object *unstructured.Unstructured
 
 	Group     string
+	Version   string
 	Kind      string
-	Name      string
-	Namespace string
+	name      string
+	namespace string
 
 	json []byte
 }
@@ -61,9 +62,10 @@ func ParseJSONToObject(json []byte) (*Object, error) {
 	return &Object{
 		object:    u,
 		Group:     gvk.Group,
+		Version:   gvk.Version,
 		Kind:      gvk.Kind,
-		Name:      u.GetName(),
-		Namespace: u.GetNamespace(),
+		name:      u.GetName(),
+		namespace: u.GetNamespace(),
 		json:      json,
 	}, nil
 }
@@ -81,6 +83,30 @@ func (o *Object) AddLabels(labels map[string]string) {
 	o.object.SetLabels(merged)
 	// Invalidate cached json
 	o.json = nil
+}
+
+func (o *Object) GetNamespace() string {
+	return o.namespace
+}
+
+func (o *Object) SetNamespace(ns string) error {
+	if err := o.SetNestedField(ns, "metadata", "namespace"); err != nil {
+		return fmt.Errorf("failed to set namespace: %w", err)
+	}
+	o.namespace = ns
+	return nil
+}
+
+func (o *Object) GetName() string {
+	return o.name
+}
+
+func (o *Object) SetName(name string) error {
+	if err := o.SetNestedField(name, "metadata", "name"); err != nil {
+		return fmt.Errorf("failed to set name: %w", err)
+	}
+	o.name = name
+	return nil
 }
 
 func (o *Object) SetNestedStringMap(value map[string]string, fields ...string) error {
@@ -289,7 +315,7 @@ func (o *Objects) Sort(score func(o *Object) int) {
 			(iScore == jScore &&
 				o.Items[i].Group == o.Items[j].Group &&
 				o.Items[i].Kind == o.Items[j].Kind &&
-				o.Items[i].Name < o.Items[j].Name)
+				o.Items[i].name < o.Items[j].name)
 	})
 }
 
@@ -361,8 +387,8 @@ func newObject(u *unstructured.Unstructured, json []byte) (*Object, error) {
 	gvk := u.GetObjectKind().GroupVersionKind()
 	o.Group = gvk.Group
 	o.Kind = gvk.Kind
-	o.Name = u.GetName()
-	o.Namespace = u.GetNamespace()
+	o.name = u.GetName()
+	o.namespace = u.GetNamespace()
 
 	return o, nil
 }

--- a/pkg/patterns/declarative/pkg/manifest/objects_test.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects_test.go
@@ -861,7 +861,7 @@ func Test_Sort(t *testing.T) {
 				},
 			},
 		},
-		Name:  "frontend111",
+		name:  "frontend111",
 		Kind:  "Deployment",
 		Group: "apps",
 	}
@@ -875,7 +875,7 @@ func Test_Sort(t *testing.T) {
 				},
 			},
 		},
-		Name:  "frontend22222",
+		name:  "frontend22222",
 		Kind:  "Deployment",
 		Group: "apps",
 	}
@@ -889,7 +889,7 @@ func Test_Sort(t *testing.T) {
 				},
 			},
 		},
-		Name:  "frontend-service",
+		name:  "frontend-service",
 		Kind:  "Service",
 		Group: "",
 	}
@@ -903,7 +903,7 @@ func Test_Sort(t *testing.T) {
 				},
 			},
 		},
-		Name:  "serviceaccount",
+		name:  "serviceaccount",
 		Kind:  "ServiceAccount",
 		Group: "",
 	}
@@ -929,7 +929,7 @@ func Test_Sort(t *testing.T) {
 				},
 			},
 			error:     false,
-			scoreFunc: func(o *Object) int { return len(o.Name) },
+			scoreFunc: func(o *Object) int { return len(o.GetName()) },
 		},
 		{
 			name: "sort with Group",

--- a/pkg/patterns/declarative/watch.go
+++ b/pkg/patterns/declarative/watch.go
@@ -166,8 +166,8 @@ func (w *watchAll) Notify(ctx context.Context, dest DeclarativeObject, objs *man
 		key := fmt.Sprintf("gvk=%s:%s:%s;labels=%s", gvk.Group, gvk.Version, gvk.Kind, filter.LabelSelector)
 
 		filterNamespace := ""
-		if w.options.ScopeWatchesToNamespace && obj.Namespace != "" {
-			filterNamespace = obj.Namespace
+		if w.options.ScopeWatchesToNamespace && obj.GetNamespace() != "" {
+			filterNamespace = obj.GetNamespace()
 			key += ";namespace=" + filterNamespace
 		}
 


### PR DESCRIPTION
This allows changing them - in particular setting the namespace.
Without this if the Namespace field was changed, it would not be
reflected in the underlying object.
    
This is also more similar to unstructured.Unstructured, which we are
modelling after.

Also proposing that we think of this as the first breaking change for 0.12.  We can continue to cherry-pick back to 0.11 though!
