### PR TITLE
check object scope before fetching

### DIFF
--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -606,8 +606,11 @@ func GetObjectFromCluster(obj *manifest.Object, r *Reconciler) (*unstructured.Un
 	if err != nil {
 		return nil, fmt.Errorf("unable to get mapping for resource %v: %w", gvk, err)
 	}
-	ns := obj.GetNamespace()
-	name := obj.GetName()
+
+	ns, name := "", obj.GetName()
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		ns = obj.GetNamespace()
+	}
 	unstruct, err := r.dynamicClient.Resource(mapping.Resource).Namespace(ns).Get(context.Background(), name, getOptions)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get object: %w", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:

if `metadata.namespace` on Cluster-level resource(such as ClusterRole) is set, `kubectl apply` will not report an error and just ignore it. But when I submit via Controller, it failed and report an error like `resource xxx is not found`. 

After some time I dug, I realize that `namespace` is joined into the URL. So maybe we should check whether the resource is Cluster-level, and ignore `metadata.namespace` if it's positive.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

