### PR TITLE
Allow multiple resources in manifest files when using kustomize

### DIFF
--- a/examples/guestbook-operator/channels/packages/guestbook/0.1.0/kustomization.yaml
+++ b/examples/guestbook-operator/channels/packages/guestbook/0.1.0/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- manifest.yaml

--- a/examples/guestbook-operator/controllers/guestbook_controller.go
+++ b/examples/guestbook-operator/controllers/guestbook_controller.go
@@ -59,6 +59,7 @@ func (r *GuestbookReconciler) setupReconciler(mgr ctrl.Manager) error {
 		declarative.WithStatus(status.NewBasic(mgr.GetClient())),
 		declarative.WithApplyPrune(),
 		declarative.WithObjectTransform(addon.ApplyPatches),
+		declarative.WithApplyKustomize(),
 
 		// Add other optional options for testing
 		declarative.WithApplyValidation(),

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -324,15 +324,19 @@ func (r *Reconciler) BuildDeploymentObjectsWithFs(ctx context.Context, name type
 		}
 
 		if fs != nil {
-			// 5. Write objects to filesystem for kustomizing
+			// 5. Write objects to filesystem for kustomizing, allow multiple objects in a file
+			finalJson := []byte("")
+			separator := []byte("---\n")
 			for _, item := range objects.Items {
 				json, err := item.JSON()
 				if err != nil {
 					log.Error(err, "error converting object to json")
 					return nil, err
 				}
-				fs.WriteFile(string(manifestPath), json)
+				finalJson = append(finalJson, separator...)
+				finalJson = append(finalJson, json...)
 			}
+			fs.WriteFile(string(manifestPath), finalJson)
 			for _, blob := range objects.Blobs {
 				fs.WriteFile(string(manifestPath), blob)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
If there are multiple resources in a manifest, and `WithApplyKustomize` option is used, the resulting manifests to apply would only contain the last item from the manifest. This PR corrects this, and takes into account that a manifest could contain multiple resources.


