### PR TITLE
RESTMapper optimized for controllers

### DIFF
--- a/pkg/mocks/mockkubeapiserver/apiserver.go
+++ b/pkg/mocks/mockkubeapiserver/apiserver.go
@@ -1,0 +1,146 @@
+package mockkubeapiserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+func NewMockKubeAPIServer(addr string) (*MockKubeAPIServer, error) {
+	s := &MockKubeAPIServer{}
+	if addr == "" {
+		addr = ":http"
+	}
+
+	s.httpServer = &http.Server{Addr: addr, Handler: s}
+
+	return s, nil
+}
+
+type MockKubeAPIServer struct {
+	httpServer *http.Server
+	listener   net.Listener
+
+	schema mockSchema
+}
+
+type mockSchema struct {
+	resources []mockSchemaResource
+}
+
+type mockSchemaResource struct {
+	metav1.APIResource
+}
+
+func (s *MockKubeAPIServer) StartServing() (net.Addr, error) {
+	listener, err := net.Listen("tcp", s.httpServer.Addr)
+	if err != nil {
+		return nil, err
+	}
+	s.listener = listener
+	addr := listener.Addr()
+	go func() {
+		if err := s.httpServer.Serve(s.listener); err != nil {
+			if err != http.ErrServerClosed {
+				klog.Errorf("error serving: %v", err)
+			}
+		}
+	}()
+	return addr, nil
+}
+
+func (s *MockKubeAPIServer) Stop() error {
+	return s.httpServer.Close()
+}
+
+func (s *MockKubeAPIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	tokens := strings.Split(strings.Trim(path, "/"), "/")
+	if len(tokens) == 2 {
+		if tokens[0] == "api" && tokens[1] == "v1" {
+			switch r.Method {
+			case http.MethodGet:
+				req := &apiResourcesRequest{}
+				req.Init(w, r)
+
+				err := req.Run(s)
+				if err != nil {
+					klog.Warningf("internal error for %s %s: %v", r.Method, r.URL, err)
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				}
+
+				return
+			default:
+				klog.Warningf("method not allowed for %s %s", r.Method, r.URL)
+				http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			}
+		}
+	}
+	klog.Warningf("404 for %s %s tokens=%#v", r.Method, r.URL, tokens)
+	http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+}
+
+// baseRequest is the base for our higher-level http requests
+type baseRequest struct {
+	w http.ResponseWriter
+	r *http.Request
+}
+
+func (b *baseRequest) Init(w http.ResponseWriter, r *http.Request) {
+	b.w = w
+	b.r = r
+}
+
+func (r *baseRequest) writeResponse(obj interface{}) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("error from json.Marshal on %T: %w", obj, err)
+	}
+	if _, err := r.w.Write(b); err != nil {
+		// Too late to send error response
+		klog.Warningf("error writing http response: %w", err)
+		return nil
+	}
+	return nil
+}
+
+// apiResourcesRequest is a wrapper around a request to list APIResources, such as /api/v1
+type apiResourcesRequest struct {
+	baseRequest
+}
+
+// doGetAPIV1 serves the GET /api/v1 endpoint
+func (r *apiResourcesRequest) Run(s *MockKubeAPIServer) error {
+	resourceList := &metav1.APIResourceList{}
+
+	for _, resource := range s.schema.resources {
+		apiResource := resource.APIResource
+		resourceList.APIResources = append(resourceList.APIResources, apiResource)
+	}
+
+	return r.writeResponse(resourceList)
+}
+
+// Add registers a type with the schema for the mock kubeapiserver
+func (s *MockKubeAPIServer) Add(gvk schema.GroupVersionKind, resource string, scope meta.RESTScope) {
+	r := mockSchemaResource{
+		APIResource: metav1.APIResource{
+			Name:    resource,
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind,
+		},
+	}
+	if scope.Name() == meta.RESTScopeNameNamespace {
+		r.Namespaced = true
+	}
+
+	s.schema.resources = append(s.schema.resources, r)
+}

--- a/pkg/restmapper/caching.go
+++ b/pkg/restmapper/caching.go
@@ -1,0 +1,115 @@
+package restmapper
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// cache is our cache of schema information.
+type cache struct {
+	mutex         sync.Mutex
+	groupVersions map[schema.GroupVersion]*cachedGroupVersion
+}
+
+// newCache is the constructor for a cache.
+func newCache() *cache {
+	return &cache{
+		groupVersions: make(map[schema.GroupVersion]*cachedGroupVersion),
+	}
+}
+
+// cachedGroupVersion caches (all) the resource information for a particular groupversion.
+type cachedGroupVersion struct {
+	gv    schema.GroupVersion
+	mutex sync.Mutex
+	kinds map[string]cachedGVR
+}
+
+// cachedGVR caches the information for a particular resource.
+type cachedGVR struct {
+	Resource string
+	Scope    meta.RESTScope
+}
+
+// findRESTMapping returns the RESTMapping for the specified GVK, querying discovery if not cached.
+func (c *cache) findRESTMapping(discovery discovery.DiscoveryInterface, gv schema.GroupVersion, kind string) (*meta.RESTMapping, error) {
+	c.mutex.Lock()
+	cached := c.groupVersions[gv]
+	if cached == nil {
+		cached = &cachedGroupVersion{gv: gv}
+		c.groupVersions[gv] = cached
+	}
+	c.mutex.Unlock()
+	return cached.findRESTMapping(discovery, kind)
+}
+
+// findRESTMapping returns the RESTMapping for the specified GVK, querying discovery if not cached.
+func (c *cachedGroupVersion) findRESTMapping(discovery discovery.DiscoveryInterface, kind string) (*meta.RESTMapping, error) {
+	kinds, err := c.fetch(discovery)
+	if err != nil {
+		return nil, err
+	}
+
+	cached, found := kinds[kind]
+	if !found {
+		return nil, nil
+	}
+	return &meta.RESTMapping{
+		Resource:         c.gv.WithResource(cached.Resource),
+		GroupVersionKind: c.gv.WithKind(kind),
+		Scope:            cached.Scope,
+	}, nil
+}
+
+// fetch returns the metadata, fetching it if not cached.
+func (c *cachedGroupVersion) fetch(discovery discovery.DiscoveryInterface) (map[string]cachedGVR, error) {
+	log := log.Log
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.kinds != nil {
+		return c.kinds, nil
+	}
+
+	log.Info("discovering server resources for group/version", "gv", c.gv.String())
+	resourceList, err := discovery.ServerResourcesForGroupVersion(c.gv.String())
+	if err != nil {
+		// We treat "no match" as an empty result, but any other error percolates back up
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+			return nil, nil
+		} else {
+			klog.Infof("unexpected error from ServerResourcesForGroupVersion(%v): %w", c.gv, err)
+			return nil, fmt.Errorf("error from ServerResourcesForGroupVersion(%v): %w", c.gv, err)
+		}
+	}
+
+	kinds := make(map[string]cachedGVR)
+	for i := range resourceList.APIResources {
+		resource := resourceList.APIResources[i]
+
+		// if we have a slash, then this is a subresource and we shouldn't create mappings for those.
+		if strings.Contains(resource.Name, "/") {
+			continue
+		}
+
+		scope := meta.RESTScopeRoot
+		if resource.Namespaced {
+			scope = meta.RESTScopeNamespace
+		}
+		kinds[resource.Kind] = cachedGVR{
+			Resource: resource.Name,
+			Scope:    scope,
+		}
+	}
+	c.kinds = kinds
+	return kinds, nil
+}

--- a/pkg/restmapper/controllerrestmapper.go
+++ b/pkg/restmapper/controllerrestmapper.go
@@ -1,0 +1,101 @@
+package restmapper
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// NewControllerRESTMapper is the constructor for a ControllerRESTMapper
+func NewControllerRESTMapper(cfg *rest.Config) (meta.RESTMapper, error) {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ControllerRESTMapper{
+		uncached: discoveryClient,
+		cache:    newCache(),
+	}, nil
+}
+
+// ControllerRESTMapper is a meta.RESTMapper that is optimized for controllers.
+// It caches results in memory, and minimizes discovery because we don't need shortnames etc in controllers.
+// Controllers primarily need to map from GVK -> GVR.
+type ControllerRESTMapper struct {
+	uncached discovery.DiscoveryInterface
+}
+
+var _ meta.RESTMapper = &ControllerRESTMapper{}
+
+// KindFor takes a partial resource and returns the single match.  Returns an error if there are multiple matches
+func (m *ControllerRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, fmt.Errorf("ControllerRESTMaper does not support KindFor operation")
+}
+
+// KindsFor takes a partial resource and returns the list of potential kinds in priority order
+func (m *ControllerRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, fmt.Errorf("ControllerRESTMaper does not support KindsFor operation")
+}
+
+// ResourceFor takes a partial resource and returns the single match.  Returns an error if there are multiple matches
+func (m *ControllerRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, fmt.Errorf("ControllerRESTMaper does not support ResourceFor operation")
+}
+
+// ResourcesFor takes a partial resource and returns the list of potential resource in priority order
+func (m *ControllerRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, fmt.Errorf("ControllerRESTMaper does not support ResourcesFor operation")
+}
+
+// RESTMapping identifies a preferred resource mapping for the provided group kind.
+func (m *ControllerRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	for _, version := range versions {
+		gv := schema.GroupVersion{Group: gk.Group, Version: version}
+		resourceList, err := m.uncached.ServerResourcesForGroupVersion(gv.String())
+		if err != nil {
+			// ignore "no match" errors, but any other error percolates back up
+			if meta.IsNoMatchError(err) {
+				continue
+			}
+			return nil, fmt.Errorf("error from ServerResourcesForGroupVersion(%v): %w", gv, err)
+		}
+		for i := range resourceList.APIResources {
+			resource := resourceList.APIResources[i]
+
+			// if we have a slash, then this is a subresource and we shouldn't create mappings for those.
+			if strings.Contains(resource.Name, "/") {
+				continue
+			}
+
+			if resource.Kind == gk.Kind {
+				scope := meta.RESTScopeRoot
+				if resource.Namespaced {
+					scope = meta.RESTScopeNamespace
+				}
+				return &meta.RESTMapping{
+					Resource:         gv.WithResource(resource.Name),
+					GroupVersionKind: gv.WithKind(gk.Kind),
+					Scope:            scope,
+				}, nil
+			}
+		}
+	}
+
+	return nil, &meta.NoKindMatchError{GroupKind: gk, SearchedVersions: versions}
+}
+
+// RESTMappings returns all resource mappings for the provided group kind if no
+// version search is provided. Otherwise identifies a preferred resource mapping for
+// the provided version(s).
+func (m *ControllerRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return nil, fmt.Errorf("ControllerRESTMaper does not support RESTMappings operation")
+}
+
+func (m *ControllerRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	return "", fmt.Errorf("ControllerRESTMaper does not support ResourceSingularizer operation")
+}

--- a/pkg/restmapper/controllerrestmapper_test.go
+++ b/pkg/restmapper/controllerrestmapper_test.go
@@ -1,0 +1,46 @@
+package restmapper
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+func TestRESTMapping(t *testing.T) {
+	// TODO: Add mock
+	home := homedir.HomeDir()
+	kubeconfigPath := filepath.Join(home, ".kube", "config")
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		panic(err)
+	}
+
+	restMapper, err := NewControllerRESTMapper(restConfig)
+	if err != nil {
+		t.Fatalf("error from NewControllerRESTMapper: %v", err)
+	}
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+	restMapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		t.Fatalf("error from RESTMapping(%v): %v", gvk, err)
+	}
+
+	got := fmt.Sprintf("resource:%v\ngvk:%v\nscope:%v", restMapping.Resource, restMapping.GroupVersionKind, restMapping.Scope.Name())
+	want := `
+resource:/v1, Resource=namespaces
+gvk:/v1, Kind=Namespace
+scope:root
+`
+	got = strings.TrimSpace(got)
+	want = strings.TrimSpace(want)
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("RESTMapping(%v) diff (-want +got):\n%s", gvk, diff)
+	}
+}


### PR DESCRIPTION
The default RESTMappers are very optimized around the kubectl use-case, where most of the time controllers only need to map GVK -> GVR to support an apply operation.

Start adding a RESTMapper optimized around this specific use-case.
 