### PR TITLE
Set dummy name for apply on direct.go

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -76,6 +76,7 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 
 	baseName := "declarative-direct"
 	applyFlags := apply.NewApplyFlags(f, ioStreams)
+	applyFlags.DeleteFlags.FileNameFlags.Filenames = &[]string{"dummy"}
 	applyCmd := apply.NewCmdApply(baseName, f, ioStreams)
 	applyOpts, err := applyFlags.ToOptions(applyCmd, baseName, nil)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets filename field with dummy name for appling manifest.
Before this PR, operator said errors followings:
`ERROR   applying manifest       {"error": "error getting apply options: must specify one of -f and -k"}`

I checked that this PR fixed current bug, but it's pretty rough, I think.

**Which issue(s) this PR fixes**:

Fixes #224

**Special notes for your reviewer**:

Currently, update is pretty rough, but root cause is discovered.
Feel free to comment more good approach.

**Additional documentation**:
NONE
