### PR TITLE
fix decode multi YAML doc

### DIFF
--- a/pkg/patterns/declarative/pkg/manifest/objects_test.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects_test.go
@@ -109,6 +109,50 @@ configMapGenerator:
 `,
 			},
 		},
+		{
+			name: "multi doc with comment",
+			inputManifest: `--- # first one
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: foo-operator
+  namespace: kube-system
+--- # empty doc
+# comments only
+--- # second one
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: foo-operator
+  namespace: kube-system`,
+			expectedObject: []*Object{
+				{
+					object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ServiceAccount",
+							"metadata": map[string]interface{}{
+								"name":      "foo-operator",
+								"namespace": "kube-system",
+							},
+						},
+					},
+				},
+				{
+					object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "ServiceAccount",
+							"metadata": map[string]interface{}{
+								"name":      "foo-operator",
+								"namespace": "kube-system",
+							},
+						},
+					},
+				},
+			},
+			expectedBlobs: []string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
```
previous doc
--- # THIS IS A COMMENT
---   
really doc here
```
below YAML separator is valid for `kubectl` but does not work in this repo.
1. the first separator has some comments.
2. the second separator has white space at the end of it.

In current behavior, `really doc here` will treat as a part of `previous doc`, and `really doc here` will be eaten in `yaml.Unmarshal` later.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

