### PR TITLE
Don't log an error if there are no errors during apply

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -113,8 +113,10 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 		IOStreams: ioStreams,
 	}
 
-	err = applyOpts.Run()
-	return utilerrors.NewAggregate(append(errs, fmt.Errorf("error from apply yamls: %w", err)))
+	if err := applyOpts.Run(); err != nil {
+		return utilerrors.NewAggregate(append(errs, fmt.Errorf("error from apply yamls: %w", err)))
+	}
+	return utilerrors.NewAggregate(errs)
 }
 
 // staticRESTClientGetter returns a fixed RESTClient


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
This commit fixes an issue where operators would log the following error
even when the apply succeeds without error:
```
    {
        "severity":"error",
        "timestamp":"2022-07-06T21:24:32.759Z",
        "msg":"applying manifest",
        "error":"error from apply yamls: %!w(<nil>)",
        "errorCauses":[{"error":"error from apply yamls: %!w(<nil>)"}]
    }
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

