### PR TITLE
Parsing: add more empty test cases

### DIFF
--- a/pkg/patterns/declarative/pkg/manifest/objects.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects.go
@@ -347,7 +347,7 @@ func ParseObjects(ctx context.Context, manifest string) (*Objects, error) {
 				return objects, nil
 			}
 
-			return nil, fmt.Errorf("invalid YAML doc, %w", err)
+			return nil, fmt.Errorf("invalid YAML doc: %w", err)
 		}
 
 		raw = bytes.TrimSpace(raw)

--- a/pkg/patterns/declarative/pkg/manifest/objects_test.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects_test.go
@@ -153,6 +153,24 @@ metadata:
 			},
 			expectedBlobs: []string{},
 		},
+		{
+			name: "empty doc",
+			inputManifest: `
+`,
+			expectedObject: []*Object{},
+			expectedBlobs:  []string{},
+		},
+		{
+			name: "empty objects",
+			inputManifest: `
+---
+null
+---
+---
+`,
+			expectedObject: []*Object{},
+			expectedBlobs:  []string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add some test cases for the empty object cases, as these have been
problematic in the past.
