### PR TITLE
Fix bug where Reconcile() returns nil err if status option is not nil

### DIFF
--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -170,8 +170,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 
 		if r.options.status != nil {
-			if err = r.options.status.Reconciled(ctx, instance, objects, err); err != nil {
-				log.Error(err, "failed to reconcile status")
+			if statusErr := r.options.status.Reconciled(ctx, instance, objects, err); statusErr != nil {
+				log.Error(statusErr, "failed to reconcile status")
 			}
 		}
 	}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:

This commit fixes an issue where `Reconcile()` can return a nil `err`,
even if an error occured during execution, as long as the `status`
option is not nil.

This bug effectively hid from callers of `Reconcile()` if an error
occurred.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

This issue seems to have originated from https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/pull/199.
