### PR TITLE
More mock testing

### DIFF
--- a/pkg/mocks/mockkubeapiserver/apigrouplist.go
+++ b/pkg/mocks/mockkubeapiserver/apigrouplist.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"context"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// apiGroupList is a request for api discovery, such as GET /apis
+type apiGroupList struct {
+	baseRequest
+}
+
+// Run serves the GET /apis endpoint
+func (r *apiGroupList) Run(ctx context.Context, s *MockKubeAPIServer) error {
+	groupMap := make(map[string]*metav1.APIGroup)
+	for _, resource := range s.storage.AllResources() {
+		group := groupMap[resource.Group]
+		if group == nil {
+			group = &metav1.APIGroup{Name: resource.Group}
+			groupMap[resource.Group] = group
+		}
+
+		foundVersion := false
+		for _, version := range group.Versions {
+			if version.Version == resource.Version {
+				foundVersion = true
+			}
+		}
+		if !foundVersion {
+			group.Versions = append(group.Versions, metav1.GroupVersionForDiscovery{
+				GroupVersion: resource.Group + "/" + resource.Version,
+				Version:      resource.Version,
+			})
+		}
+	}
+
+	for _, group := range groupMap {
+		sort.Slice(group.Versions, func(i, j int) bool {
+			return group.Versions[i].Version < group.Versions[j].Version
+		})
+	}
+
+	var groupKeys []string
+	for key := range groupMap {
+		groupKeys = append(groupKeys, key)
+	}
+	sort.Strings(groupKeys)
+
+	response := &metav1.APIGroupList{}
+	response.Kind = "APIGroupList"
+	response.APIVersion = "v1"
+	for _, groupKey := range groupKeys {
+		group := groupMap[groupKey]
+		// Assume preferred version is newest
+		group.PreferredVersion = group.Versions[len(group.Versions)-1]
+		response.Groups = append(response.Groups, *group)
+	}
+	return r.writeResponse(response)
+}

--- a/pkg/mocks/mockkubeapiserver/apiresourcelist.go
+++ b/pkg/mocks/mockkubeapiserver/apiresourcelist.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// apiResourceList is a request for api discovery, such as GET /apis/resourcemanager.cnrm.cloud.google.com/v1beta1
+type apiResourceList struct {
+	baseRequest
+
+	Group   string
+	Version string
+}
+
+// Run serves the http request
+func (req *apiResourceList) Run(ctx context.Context, s *MockKubeAPIServer) error {
+	gv := schema.GroupVersion{
+		Group:   req.Group,
+		Version: req.Version,
+	}
+	response := &metav1.APIResourceList{}
+	response.Kind = "APIResourceList"
+	response.APIVersion = "v1"
+	response.GroupVersion = gv.String()
+	for _, resource := range s.storage.AllResources() {
+		if resource.Group != req.Group || resource.Version != req.Version {
+			continue
+		}
+		response.APIResources = append(response.APIResources, resource)
+	}
+	return req.writeResponse(response)
+}

--- a/pkg/mocks/mockkubeapiserver/apiserver.go
+++ b/pkg/mocks/mockkubeapiserver/apiserver.go
@@ -90,7 +90,17 @@ func (s *MockKubeAPIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+
+		if tokens[0] == "openapi" && tokens[1] == "v2" {
+			matchedPath = true
+
+			switch r.Method {
+			case http.MethodGet:
+				req = &openapiRequest{}
+			}
+		}
 	}
+
 	if len(tokens) == 1 {
 		if tokens[0] == "api" {
 			matchedPath = true

--- a/pkg/mocks/mockkubeapiserver/apiserver.go
+++ b/pkg/mocks/mockkubeapiserver/apiserver.go
@@ -21,8 +21,6 @@ import (
 	"net/http"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 )
 
@@ -166,6 +164,7 @@ func (s *MockKubeAPIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			matchedPath = true
 		}
 	}
+
 	if len(tokens) == 6 {
 		if tokens[0] == "api" && tokens[2] == "namespaces" {
 			buildObjectRequest(resourceRequestBase{
@@ -222,9 +221,4 @@ func (s *MockKubeAPIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		klog.Warningf("internal error for %s %s: %v", r.Method, r.URL, err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
-}
-
-// RegisterType registers a type with the schema for the mock kubeapiserver
-func (s *MockKubeAPIServer) RegisterType(gvk schema.GroupVersionKind, resource string, scope meta.RESTScope) {
-	s.storage.RegisterType(gvk, resource, scope)
 }

--- a/pkg/mocks/mockkubeapiserver/apiserver.go
+++ b/pkg/mocks/mockkubeapiserver/apiserver.go
@@ -1,14 +1,27 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mockkubeapiserver
 
 import (
-	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 )
@@ -21,6 +34,8 @@ func NewMockKubeAPIServer(addr string) (*MockKubeAPIServer, error) {
 
 	s.httpServer = &http.Server{Addr: addr, Handler: s}
 
+	s.storage = NewMemoryStorage()
+
 	return s, nil
 }
 
@@ -28,15 +43,7 @@ type MockKubeAPIServer struct {
 	httpServer *http.Server
 	listener   net.Listener
 
-	schema mockSchema
-}
-
-type mockSchema struct {
-	resources []mockSchemaResource
-}
-
-type mockSchemaResource struct {
-	metav1.APIResource
+	storage *MemoryStorage
 }
 
 func (s *MockKubeAPIServer) StartServing() (net.Addr, error) {
@@ -61,86 +68,163 @@ func (s *MockKubeAPIServer) Stop() error {
 }
 
 func (s *MockKubeAPIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	klog.Infof("kubeapiserver request: %s %s", r.Method, r.URL)
+
 	path := r.URL.Path
 	tokens := strings.Split(strings.Trim(path, "/"), "/")
+
+	var req Request
+
+	// matchedPath is bool if we recognized the path, but if we didn't build a req we should send StatusMethodNotAllowed instead of NotFound
+	var matchedPath bool
+
 	if len(tokens) == 2 {
 		if tokens[0] == "api" && tokens[1] == "v1" {
+			matchedPath = true
+
 			switch r.Method {
 			case http.MethodGet:
-				req := &apiResourcesRequest{}
-				req.Init(w, r)
-
-				err := req.Run(s)
-				if err != nil {
-					klog.Warningf("internal error for %s %s: %v", r.Method, r.URL, err)
-					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				req = &apiResourceList{
+					Group:   "",
+					Version: "v1",
 				}
-
-				return
-			default:
-				klog.Warningf("method not allowed for %s %s", r.Method, r.URL)
-				http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 			}
 		}
 	}
-	klog.Warningf("404 for %s %s tokens=%#v", r.Method, r.URL, tokens)
-	http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
-}
+	if len(tokens) == 1 {
+		if tokens[0] == "api" {
+			matchedPath = true
 
-// baseRequest is the base for our higher-level http requests
-type baseRequest struct {
-	w http.ResponseWriter
-	r *http.Request
-}
+			switch r.Method {
+			case http.MethodGet:
+				req = &apiVersionsRequest{}
+			}
+		}
 
-func (b *baseRequest) Init(w http.ResponseWriter, r *http.Request) {
-	b.w = w
-	b.r = r
-}
+		if tokens[0] == "apis" {
+			matchedPath = true
+			switch r.Method {
+			case http.MethodGet:
+				req = &apiGroupList{}
+			}
+		}
+	}
 
-func (r *baseRequest) writeResponse(obj interface{}) error {
-	b, err := json.Marshal(obj)
+	if len(tokens) == 3 {
+		if tokens[0] == "apis" {
+			matchedPath = true
+			switch r.Method {
+			case http.MethodGet:
+				req = &apiResourceList{
+					Group:   tokens[1],
+					Version: tokens[2],
+				}
+			}
+		}
+
+		if tokens[0] == "api" && tokens[1] == "v1" {
+			matchedPath = true
+			switch r.Method {
+			case http.MethodPost:
+				req = &postResource{
+					Group:     "",
+					Version:   tokens[1],
+					Resource:  tokens[2],
+					Namespace: "",
+				}
+			}
+		}
+	}
+
+	buildObjectRequest := func(common resourceRequestBase) {
+		switch r.Method {
+		case http.MethodGet:
+			req = &getResource{
+				resourceRequestBase: common,
+			}
+		case http.MethodPatch:
+			req = &patchResource{
+				resourceRequestBase: common,
+			}
+		case http.MethodPut:
+			req = &putResource{
+				resourceRequestBase: common,
+			}
+		}
+	}
+
+	if len(tokens) == 4 {
+		if tokens[0] == "api" {
+			buildObjectRequest(resourceRequestBase{
+				Group:    "",
+				Version:  tokens[1],
+				Resource: tokens[2],
+				Name:     tokens[3],
+			})
+			matchedPath = true
+		}
+	}
+	if len(tokens) == 6 {
+		if tokens[0] == "api" && tokens[2] == "namespaces" {
+			buildObjectRequest(resourceRequestBase{
+				Group:     "",
+				Version:   tokens[1],
+				Resource:  tokens[4],
+				Namespace: tokens[3],
+				Name:      tokens[5],
+			})
+			matchedPath = true
+		}
+	}
+	if len(tokens) == 7 {
+		if tokens[0] == "apis" && tokens[3] == "namespaces" {
+			buildObjectRequest(resourceRequestBase{
+				Group:     tokens[1],
+				Version:   tokens[2],
+				Namespace: tokens[4],
+				Resource:  tokens[5],
+				Name:      tokens[6],
+			})
+			matchedPath = true
+		}
+	}
+	if len(tokens) == 8 {
+		if tokens[0] == "apis" && tokens[3] == "namespaces" {
+			buildObjectRequest(resourceRequestBase{
+				Group:       tokens[1],
+				Version:     tokens[2],
+				Namespace:   tokens[4],
+				Resource:    tokens[5],
+				Name:        tokens[6],
+				SubResource: tokens[7],
+			})
+			matchedPath = true
+		}
+	}
+
+	if req == nil {
+		if matchedPath {
+			klog.Warningf("method not allowed for %s %s", r.Method, r.URL)
+			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		} else {
+			klog.Warningf("404 for %s %s tokens=%#v", r.Method, r.URL, tokens)
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		}
+		return
+	}
+
+	req.Init(w, r)
+
+	err := req.Run(ctx, s)
 	if err != nil {
-		return fmt.Errorf("error from json.Marshal on %T: %w", obj, err)
+		klog.Warningf("internal error for %s %s: %v", r.Method, r.URL, err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
-	if _, err := r.w.Write(b); err != nil {
-		// Too late to send error response
-		klog.Warningf("error writing http response: %w", err)
-		return nil
-	}
-	return nil
 }
 
-// apiResourcesRequest is a wrapper around a request to list APIResources, such as /api/v1
-type apiResourcesRequest struct {
-	baseRequest
-}
-
-// doGetAPIV1 serves the GET /api/v1 endpoint
-func (r *apiResourcesRequest) Run(s *MockKubeAPIServer) error {
-	resourceList := &metav1.APIResourceList{}
-
-	for _, resource := range s.schema.resources {
-		apiResource := resource.APIResource
-		resourceList.APIResources = append(resourceList.APIResources, apiResource)
-	}
-
-	return r.writeResponse(resourceList)
-}
-
-// Add registers a type with the schema for the mock kubeapiserver
-func (s *MockKubeAPIServer) Add(gvk schema.GroupVersionKind, resource string, scope meta.RESTScope) {
-	r := mockSchemaResource{
-		APIResource: metav1.APIResource{
-			Name:    resource,
-			Group:   gvk.Group,
-			Version: gvk.Version,
-			Kind:    gvk.Kind,
-		},
-	}
-	if scope.Name() == meta.RESTScopeNameNamespace {
-		r.Namespaced = true
-	}
-
-	s.schema.resources = append(s.schema.resources, r)
+// RegisterType registers a type with the schema for the mock kubeapiserver
+func (s *MockKubeAPIServer) RegisterType(gvk schema.GroupVersionKind, resource string, scope meta.RESTScope) {
+	s.storage.RegisterType(gvk, resource, scope)
 }

--- a/pkg/mocks/mockkubeapiserver/apiversions.go
+++ b/pkg/mocks/mockkubeapiserver/apiversions.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mockkubeapiserver
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// apiVersionsRequest is a wrapper around a request for core api version, such as GET /api
+type apiVersionsRequest struct {
+	baseRequest
+}
+
+// Run serves the GET /api endpoint
+func (r *apiVersionsRequest) Run(ctx context.Context, s *MockKubeAPIServer) error {
+	versions := &metav1.APIVersions{}
+	versions.Kind = "APIVersions"
+	versions.Versions = []string{"v1"}
+
+	return r.writeResponse(versions)
+}

--- a/pkg/mocks/mockkubeapiserver/controllers.go
+++ b/pkg/mocks/mockkubeapiserver/controllers.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func (s *MemoryStorage) objectChanged(u *unstructured.Unstructured) {
+	gvk := u.GroupVersionKind()
+
+	switch gvk.GroupKind() {
+	case schema.GroupKind{Kind: "Namespace"}:
+		s.namespaceChanged(u)
+	}
+}
+
+func (s *MemoryStorage) namespaceChanged(u *unstructured.Unstructured) {
+	// These changes seem to be done synchronously (similar to a mutating webhook)
+	labels := u.GetLabels()
+	name := u.GetName()
+	if labels["kubernetes.io/metadata.name"] != name {
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels["kubernetes.io/metadata.name"] = name
+		u.SetLabels(labels)
+	}
+	phase, _, _ := unstructured.NestedFieldNoCopy(u.Object, "status", "phase")
+	if phase != "Active" {
+		unstructured.SetNestedField(u.Object, "Active", "status", "phase")
+	}
+	found := false
+	finalizers, _, _ := unstructured.NestedSlice(u.Object, "spec", "finalizers")
+	for _, finalizer := range finalizers {
+		if finalizer == "kubernetes" {
+			found = true
+		}
+	}
+	if !found {
+		finalizers = append(finalizers, "kubernetes")
+		unstructured.SetNestedSlice(u.Object, finalizers, "spec", "finalizers")
+	}
+}

--- a/pkg/mocks/mockkubeapiserver/getresource.go
+++ b/pkg/mocks/mockkubeapiserver/getresource.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// resourceRequestBase holds the common field for single-resource requests
+type resourceRequestBase struct {
+	baseRequest
+
+	Group     string
+	Version   string
+	Resource  string
+	Namespace string
+	Name      string
+
+	SubResource string
+}
+
+// getResource is a request to get a single resource
+type getResource struct {
+	resourceRequestBase
+}
+
+// Run serves the http request
+func (req *getResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
+	gr := schema.GroupResource{Group: req.Group, Resource: req.Resource}
+
+	id := types.NamespacedName{Namespace: req.Namespace, Name: req.Name}
+
+	object, found, err := s.storage.GetObject(ctx, gr, id)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return req.writeErrorResponse(http.StatusNotFound)
+	}
+
+	j, err := json.Marshal(object)
+	if err != nil {
+		klog.Warningf("object does not marshal: %v", err)
+	} else {
+		klog.Infof("returning %v", string(j))
+	}
+	return req.writeResponse(object)
+}

--- a/pkg/mocks/mockkubeapiserver/memorystorage.go
+++ b/pkg/mocks/mockkubeapiserver/memorystorage.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mockkubeapiserver
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type MemoryStorage struct {
+	mutex   sync.Mutex
+	schema  mockSchema
+	objects map[schema.GroupResource]*objectList
+}
+
+func NewMemoryStorage() *MemoryStorage {
+	s := &MemoryStorage{
+		objects: make(map[schema.GroupResource]*objectList),
+	}
+	return s
+}
+
+type mockSchema struct {
+	resources []mockSchemaResource
+}
+
+type mockSchemaResource struct {
+	metav1.APIResource
+}
+
+type objectList struct {
+	GroupResource schema.GroupResource
+	Objects       map[types.NamespacedName]*unstructured.Unstructured
+}
+
+// AddObject pre-creates an object
+func (s *MemoryStorage) AddObject(obj *unstructured.Unstructured) error {
+	ctx := context.Background()
+
+	gv, err := schema.ParseGroupVersion(obj.GetAPIVersion())
+	if err != nil {
+		return fmt.Errorf("cannot parse apiVersion %q: %w", obj.GetAPIVersion(), err)
+	}
+	kind := obj.GetKind()
+
+	id := types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+
+	for _, resource := range s.schema.resources {
+		if resource.Group != gv.Group || resource.Version != gv.Version {
+			continue
+		}
+		if resource.Kind != kind {
+			continue
+		}
+
+		gr := schema.GroupResource{Group: resource.Group, Resource: resource.Name}
+
+		return s.PutObject(ctx, gr, id, obj)
+	}
+	gvk := gv.WithKind(kind)
+	return fmt.Errorf("object group/version/kind %v not known", gvk)
+}
+
+func (s *MemoryStorage) GetObject(ctx context.Context, gr schema.GroupResource, id types.NamespacedName) (*unstructured.Unstructured, bool, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	objects := s.objects[gr]
+	if objects == nil {
+		return nil, false, nil
+	}
+
+	object := objects.Objects[id]
+	if object == nil {
+		return nil, false, nil
+	}
+
+	return object, true, nil
+}
+
+func (s *MemoryStorage) PutObject(ctx context.Context, gr schema.GroupResource, id types.NamespacedName, u *unstructured.Unstructured) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	objects := s.objects[gr]
+	if objects == nil {
+		objects = &objectList{
+			GroupResource: gr,
+			Objects:       make(map[types.NamespacedName]*unstructured.Unstructured),
+		}
+		s.objects[gr] = objects
+	}
+
+	objects.Objects[id] = u
+	s.objectChanged(u)
+	return nil
+}
+
+// RegisterType registers a type with the schema for the mock kubeapiserver
+func (s *MemoryStorage) RegisterType(gvk schema.GroupVersionKind, resource string, scope meta.RESTScope) {
+	r := mockSchemaResource{
+		APIResource: metav1.APIResource{
+			Name:    resource,
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind,
+		},
+	}
+	if scope.Name() == meta.RESTScopeNameNamespace {
+		r.Namespaced = true
+	}
+
+	s.schema.resources = append(s.schema.resources, r)
+}
+
+func (s *MemoryStorage) AllResources() []metav1.APIResource {
+	var ret []metav1.APIResource
+	for _, resource := range s.schema.resources {
+		ret = append(ret, resource.APIResource)
+	}
+	return ret
+}

--- a/pkg/mocks/mockkubeapiserver/openapi_request.go
+++ b/pkg/mocks/mockkubeapiserver/openapi_request.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+)
+
+// openapiRequest is a request to patch a single resource
+type openapiRequest struct {
+	resourceRequestBase
+}
+
+// Run serves the http request
+func (req *openapiRequest) Run(ctx context.Context, s *MockKubeAPIServer) error {
+	klog.Warningf("returning empty information for openapi/v2 request")
+
+	b := []byte{}
+	w := req.baseRequest.w
+	w.Header().Add("Content-Type", "application/com.github.proto-openapi.spec.v2")
+	w.Header().Add("Cache-Control", "no-cache, private")
+
+	if _, err := w.Write(b); err != nil {
+		// Too late to send error response
+		klog.Warningf("error writing http response: %v", err)
+		return nil
+	}
+	return nil
+}

--- a/pkg/mocks/mockkubeapiserver/patchresource.go
+++ b/pkg/mocks/mockkubeapiserver/patchresource.go
@@ -18,6 +18,7 @@ package mockkubeapiserver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -52,8 +53,9 @@ func (req *patchResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
 	}
 
 	body := &unstructured.Unstructured{}
-	if err := body.UnmarshalJSON(bodyBytes); err != nil {
-		return fmt.Errorf("failed to parse payload: %w", err)
+	// Can't use the MarshalJSON overload, it doesn't like missing kind etc
+	if err := json.Unmarshal(bodyBytes, &body.Object); err != nil {
+		return fmt.Errorf("failed to parse PATCH payload: %w", err)
 	}
 
 	// TODO: We need to implement patch properly

--- a/pkg/mocks/mockkubeapiserver/patchresource.go
+++ b/pkg/mocks/mockkubeapiserver/patchresource.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// patchResource is a request to patch a single resource
+type patchResource struct {
+	resourceRequestBase
+}
+
+// Run serves the http request
+func (req *patchResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
+	gr := schema.GroupResource{Group: req.Group, Resource: req.Resource}
+
+	id := types.NamespacedName{Namespace: req.Namespace, Name: req.Name}
+	existing, found, err := s.storage.GetObject(ctx, gr, id)
+	if err != nil {
+		return err
+	}
+	if !found {
+		existing = nil
+	}
+
+	bodyBytes, err := ioutil.ReadAll(req.r.Body)
+	if err != nil {
+		return err
+	}
+
+	body := &unstructured.Unstructured{}
+	if err := body.UnmarshalJSON(bodyBytes); err != nil {
+		return fmt.Errorf("failed to parse payload: %w", err)
+	}
+
+	// TODO: We need to implement patch properly
+	klog.Infof("patch request %#v", string(bodyBytes))
+
+	if !found {
+		// TODO: Only if server-side-apply
+
+		if req.SubResource != "" {
+			// TODO: Is this correct for server-side-apply?
+			return req.writeErrorResponse(http.StatusNotFound)
+		}
+
+		patched := body
+		if err := s.storage.PutObject(ctx, gr, id, patched); err != nil {
+			return err
+		}
+
+		return req.writeResponse(patched)
+	}
+
+	if req.SubResource == "" {
+		if err := applyPatch(existing.Object, body.Object); err != nil {
+			klog.Warningf("error from patch: %v", err)
+			return err
+		}
+	} else {
+		// TODO: We need to implement put properly
+		return fmt.Errorf("unknown subresource %q", req.SubResource)
+	}
+
+	if err := s.storage.PutObject(ctx, gr, id, existing); err != nil {
+		return err
+	}
+	return req.writeResponse(existing)
+}
+
+func applyPatch(existing, patch map[string]interface{}) error {
+	for k, patchValue := range patch {
+		existingValue := existing[k]
+		switch patchValue := patchValue.(type) {
+		case string, int64:
+			existing[k] = patchValue
+		case map[string]interface{}:
+			if existingValue == nil {
+				existing[k] = patchValue
+			} else {
+				existingMap, ok := existingValue.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("unexpected type mismatch, expected map got %T", existingValue)
+				}
+				if err := applyPatch(existingMap, patchValue); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("type %T not handled in patch", patchValue)
+		}
+	}
+	return nil
+}

--- a/pkg/mocks/mockkubeapiserver/postresource.go
+++ b/pkg/mocks/mockkubeapiserver/postresource.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// postResource is a request to create a new resource
+type postResource struct {
+	baseRequest
+
+	Group    string
+	Version  string
+	Resource string
+
+	Namespace string
+}
+
+// Run serves the http request
+func (req *postResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
+	gr := schema.GroupResource{Group: req.Group, Resource: req.Resource}
+
+	bodyBytes, err := ioutil.ReadAll(req.r.Body)
+	if err != nil {
+		return err
+	}
+
+	klog.V(4).Infof("post request %#v", string(bodyBytes))
+
+	body := &unstructured.Unstructured{}
+	if err := body.UnmarshalJSON(bodyBytes); err != nil {
+		return fmt.Errorf("failed to parse payload: %w", err)
+	}
+
+	id := types.NamespacedName{Namespace: body.GetNamespace(), Name: body.GetName()}
+
+	if id.Namespace != req.Namespace {
+		return fmt.Errorf("namespace in payload did not match namespace in URL")
+	}
+	if id.Name == "" {
+		return fmt.Errorf("name must be provided in payload")
+	}
+
+	_, found, err := s.storage.GetObject(ctx, gr, id)
+	if found {
+		return req.writeErrorResponse(http.StatusConflict)
+	}
+
+	if err := s.storage.PutObject(ctx, gr, id, body); err != nil {
+		return err
+	}
+	return req.writeResponse(body)
+}

--- a/pkg/mocks/mockkubeapiserver/putresource.go
+++ b/pkg/mocks/mockkubeapiserver/putresource.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// putResource is a request to get a single resource
+type putResource struct {
+	resourceRequestBase
+}
+
+// Run serves the http request
+func (req *putResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
+	gr := schema.GroupResource{Group: req.Group, Resource: req.Resource}
+
+	id := types.NamespacedName{Namespace: req.Namespace, Name: req.Name}
+
+	existing, found, err := s.storage.GetObject(ctx, gr, id)
+	if !found {
+		return req.writeErrorResponse(http.StatusNotFound)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(req.r.Body)
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("put request %#v", string(bodyBytes))
+
+	body := &unstructured.Unstructured{}
+	if err := body.UnmarshalJSON(bodyBytes); err != nil {
+		return fmt.Errorf("failed to parse payload: %w", err)
+	}
+
+	var updated *unstructured.Unstructured
+
+	if req.SubResource == "" {
+		updated = body
+	} else if req.SubResource == "status" {
+		updated = existing.DeepCopyObject().(*unstructured.Unstructured)
+		newStatus := body.Object["status"]
+		if newStatus == nil {
+			// TODO: This might be allowed?
+			return fmt.Errorf("status not specified on status subresource update")
+		}
+		updated.Object["status"] = newStatus
+	} else {
+		// TODO: We need to implement put properly
+		return fmt.Errorf("unknown subresource %q", req.SubResource)
+	}
+
+	if err := s.storage.PutObject(ctx, gr, id, updated); err != nil {
+		return err
+	}
+	return req.writeResponse(updated)
+}

--- a/pkg/mocks/mockkubeapiserver/request.go
+++ b/pkg/mocks/mockkubeapiserver/request.go
@@ -58,7 +58,7 @@ func (r *baseRequest) writeResponse(obj interface{}) error {
 }
 
 func (r *baseRequest) writeErrorResponse(statusCode int) error {
-	klog.Warningf("404 for %s %s", r.r.Method, r.r.URL)
+	klog.Warningf("%d for %s %s", statusCode, r.r.Method, r.r.URL)
 	http.Error(r.w, http.StatusText(statusCode), statusCode)
 
 	return nil

--- a/pkg/mocks/mockkubeapiserver/request.go
+++ b/pkg/mocks/mockkubeapiserver/request.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"k8s.io/klog/v2"
+)
+
+type Request interface {
+	Run(ctx context.Context, s *MockKubeAPIServer) error
+	Init(w http.ResponseWriter, r *http.Request)
+}
+
+// baseRequest is the base for our higher-level http requests
+type baseRequest struct {
+	w http.ResponseWriter
+	r *http.Request
+}
+
+func (b *baseRequest) Init(w http.ResponseWriter, r *http.Request) {
+	b.w = w
+	b.r = r
+}
+
+func (r *baseRequest) writeResponse(obj interface{}) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("error from json.Marshal on %T: %w", obj, err)
+	}
+	r.w.Header().Add("Content-Type", "application/json")
+	r.w.Header().Add("Cache-Control", "no-cache, private")
+
+	if _, err := r.w.Write(b); err != nil {
+		// Too late to send error response
+		klog.Warningf("error writing http response: %v", err)
+		return nil
+	}
+	return nil
+}
+
+func (r *baseRequest) writeErrorResponse(statusCode int) error {
+	klog.Warningf("404 for %s %s", r.r.Method, r.r.URL)
+	http.Error(r.w, http.StatusText(statusCode), statusCode)
+
+	return nil
+}

--- a/pkg/mocks/mockkubeapiserver/testhelpers.go
+++ b/pkg/mocks/mockkubeapiserver/testhelpers.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockkubeapiserver
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+)
+
+// RegisterType registers a type with the schema for the mock kubeapiserver
+func (s *MockKubeAPIServer) RegisterType(gvk schema.GroupVersionKind, resource string, scope meta.RESTScope) {
+	s.storage.RegisterType(gvk, resource, scope)
+}
+
+// AddObject pre-creates an object
+func (s *MockKubeAPIServer) AddObject(obj *unstructured.Unstructured) error {
+	klog.Infof("precreating %s object %s/%s", obj.GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName())
+	return s.storage.AddObject(obj)
+}
+
+// AddObjectsFromManifest pre-creates the objects in the manifest
+func (s *MockKubeAPIServer) AddObjectsFromManifest(y string) error {
+	for _, obj := range strings.Split(y, "\n---\n") {
+		u := &unstructured.Unstructured{}
+		if err := yaml.Unmarshal([]byte(obj), &u.Object); err != nil {
+			return fmt.Errorf("failed to unmarshal object %q: %w", obj, err)
+		}
+		if err := s.AddObject(u); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/patterns/declarative/pkg/applier/direct_test.go
+++ b/pkg/patterns/declarative/pkg/applier/direct_test.go
@@ -247,6 +247,12 @@ func TestDirectApplier(t *testing.T) {
 
 		directApplier := NewDirectApplier()
 
+		if h.FileExists(filepath.Join(testdir, "before.yaml")) {
+			before := string(h.MustReadFile(filepath.Join(testdir, "before.yaml")))
+			if err := k8s.AddObjectsFromManifest(before); err != nil {
+				t.Fatalf("error precreating objects: %v", err)
+			}
+		}
 		manifest := string(h.MustReadFile(filepath.Join(testdir, "manifest.yaml")))
 
 		tmpdir := h.TempDir()

--- a/pkg/patterns/declarative/pkg/applier/direct_test.go
+++ b/pkg/patterns/declarative/pkg/applier/direct_test.go
@@ -66,7 +66,7 @@ func (d *directApplierTestSite) NewBuilder(opt ApplierOptions) *resource.Builder
 		})
 }
 
-func (d *directApplierTestSite) NewFactory() cmdutil.Factory {
+func (d *directApplierTestSite) NewFactory(opt ApplierOptions) cmdutil.Factory {
 	return kubectltesting.NewTestFactory()
 }
 

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/expected.yaml
@@ -36,6 +36,15 @@ url: http://kube-apiserver/api/v1?timeout=32s
 ---
 header:
   Accept:
+  - application/com.github.proto-openapi.spec.v2@v1.0+protobuf
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/openapi/v2?timeout=32s
+
+---
+header:
+  Accept:
   - application/json
 method: GET
 url: http://kube-apiserver/api/v1/namespaces/ns1

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/expected.yaml
@@ -1,0 +1,70 @@
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/api?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/apis?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/api/v1?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/api/v1?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json
+method: GET
+url: http://kube-apiserver/api/v1/namespaces/ns1
+
+---
+body: |
+  {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns1\"}}\n"},"name":"ns1"}}
+header:
+  Accept:
+  - application/json
+  Content-Type:
+  - application/json
+method: POST
+url: http://kube-apiserver/api/v1/namespaces?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+
+---
+header:
+  Accept:
+  - application/json
+method: GET
+url: http://kube-apiserver/api/v1/namespaces/ns2
+
+---
+body: |
+  {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns2\"}}\n"},"name":"ns2"}}
+header:
+  Accept:
+  - application/json
+  Content-Type:
+  - application/json
+method: POST
+url: http://kube-apiserver/api/v1/namespaces?fieldManager=kubectl-client-side-apply&fieldValidation=Strict

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/manifest.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/manifest.yaml
@@ -1,0 +1,11 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns1
+
+---
+
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns2

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/before.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/before.yaml
@@ -1,0 +1,11 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns1
+
+---
+
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns2

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/expected.yaml
@@ -36,6 +36,15 @@ url: http://kube-apiserver/api/v1?timeout=32s
 ---
 header:
   Accept:
+  - application/com.github.proto-openapi.spec.v2@v1.0+protobuf
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/openapi/v2?timeout=32s
+
+---
+header:
+  Accept:
   - application/json
 method: GET
 url: http://kube-apiserver/api/v1/namespaces/ns1

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/expected.yaml
@@ -1,0 +1,68 @@
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/api?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/apis?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/api/v1?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/api/v1?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json
+method: GET
+url: http://kube-apiserver/api/v1/namespaces/ns1
+
+---
+body: '{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns1\"}}\n"}}}'
+header:
+  Accept:
+  - application/json
+  Content-Type:
+  - application/strategic-merge-patch+json
+method: PATCH
+url: http://kube-apiserver/api/v1/namespaces/ns1?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+
+---
+header:
+  Accept:
+  - application/json
+method: GET
+url: http://kube-apiserver/api/v1/namespaces/ns2
+
+---
+body: '{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns2\"}}\n"}}}'
+header:
+  Accept:
+  - application/json
+  Content-Type:
+  - application/strategic-merge-patch+json
+method: PATCH
+url: http://kube-apiserver/api/v1/namespaces/ns2?fieldManager=kubectl-client-side-apply&fieldValidation=Strict

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/manifest.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/manifest.yaml
@@ -1,0 +1,11 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns1
+
+---
+
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns2

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/before.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/before.yaml
@@ -1,0 +1,15 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns1
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns1\"}}\n"
+
+---
+
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns2
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns2\"}}\n"

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/expected.yaml
@@ -1,0 +1,48 @@
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/api?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/apis?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/api/v1?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json, */*
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/api/v1?timeout=32s
+
+---
+header:
+  Accept:
+  - application/json
+method: GET
+url: http://kube-apiserver/api/v1/namespaces/ns1
+
+---
+header:
+  Accept:
+  - application/json
+method: GET
+url: http://kube-apiserver/api/v1/namespaces/ns2

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/expected.yaml
@@ -36,6 +36,15 @@ url: http://kube-apiserver/api/v1?timeout=32s
 ---
 header:
   Accept:
+  - application/com.github.proto-openapi.spec.v2@v1.0+protobuf
+  User-Agent:
+  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
+method: GET
+url: http://kube-apiserver/openapi/v2?timeout=32s
+
+---
+header:
+  Accept:
   - application/json
 method: GET
 url: http://kube-apiserver/api/v1/namespaces/ns1

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/manifest.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/manifest.yaml
@@ -1,0 +1,11 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns1
+
+---
+
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns2

--- a/pkg/restmapper/controllerrestmapper_test.go
+++ b/pkg/restmapper/controllerrestmapper_test.go
@@ -19,7 +19,7 @@ func TestRESTMapping(t *testing.T) {
 		t.Fatalf("error building mock kube-apiserver: %v", err)
 	}
 
-	k8s.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}, "namespaces", meta.RESTScopeRoot)
+	k8s.RegisterType(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}, "namespaces", meta.RESTScopeRoot)
 
 	defer func() {
 		if err := k8s.Stop(); err != nil {

--- a/pkg/test/httprecorder/http_recorder.go
+++ b/pkg/test/httprecorder/http_recorder.go
@@ -1,0 +1,38 @@
+package httprecorder
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+)
+
+type HTTPRecorder struct {
+	inner http.RoundTripper
+	log   *RequestLog
+}
+
+func NewRecorder(inner http.RoundTripper, log *RequestLog) *HTTPRecorder {
+	rt := &HTTPRecorder{inner: inner, log: log}
+	return rt
+}
+
+func (m *HTTPRecorder) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	c := Request{
+		Method: req.Method,
+		URL:    req.URL.String(),
+		Header: req.Header,
+	}
+
+	if req.Body != nil {
+		requestBody, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			panic("failed to read request body")
+		}
+		c.Body = string(requestBody)
+		req.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
+	}
+	m.log.Requests = append(m.log.Requests, c)
+
+	return m.inner.RoundTrip(req)
+}

--- a/pkg/test/httprecorder/request_log.go
+++ b/pkg/test/httprecorder/request_log.go
@@ -1,0 +1,41 @@
+package httprecorder
+
+import (
+	"net/http"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+)
+
+type Request struct {
+	Method string      `json:"method,omitempty"`
+	URL    string      `json:"url,omitempty"`
+	Header http.Header `json:"header,omitempty"`
+	Body   string      `json:"body,omitempty"`
+}
+
+type RequestLog struct {
+	Requests []Request
+}
+
+func (l *RequestLog) FormatYAML() string {
+	var actual []string
+	for _, request := range l.Requests {
+		y, err := yaml.Marshal(request)
+		if err != nil {
+			klog.Fatalf("error from yaml.Marshal: %v", err)
+		}
+		actual = append(actual, string(y))
+	}
+	return strings.Join(actual, "\n---\n")
+}
+
+func (l *RequestLog) ReplaceURLPrefix(old, new string) {
+	for i := range l.Requests {
+		r := &l.Requests[i]
+		if strings.HasPrefix(r.URL, old) {
+			r.URL = new + strings.TrimPrefix(r.URL, old)
+		}
+	}
+}

--- a/pkg/test/testharness/golden.go
+++ b/pkg/test/testharness/golden.go
@@ -1,0 +1,46 @@
+package testharness
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func RunGoldenTests(t *testing.T, basedir string, fn func(h *Harness, dir string)) {
+	files, err := ioutil.ReadDir(basedir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q) failed: %v", basedir, err)
+	}
+	for _, file := range files {
+		name := file.Name()
+		absPath := filepath.Join(basedir, name)
+		t.Run(name, func(t *testing.T) {
+			h := New(t)
+			fn(h, absPath)
+		})
+	}
+}
+
+func (h *Harness) CompareGoldenFile(p string, got string) {
+	if os.Getenv("WRITE_GOLDEN_OUTPUT") != "" {
+		// Short-circuit when the output is correct
+		b, err := ioutil.ReadFile(p)
+		if err == nil && bytes.Equal(b, []byte(got)) {
+			return
+		}
+
+		if err := ioutil.WriteFile(p, []byte(got), 0644); err != nil {
+			h.Fatalf("failed to write golden output %s: %v", p, err)
+		}
+		h.Errorf("wrote output to %s", p)
+	} else {
+		want := string(h.MustReadFile(p))
+		if diff := cmp.Diff(want, got); diff != "" {
+			h.Errorf("unexpected diff in %s: %s", p, diff)
+		}
+	}
+}

--- a/pkg/test/testharness/harness.go
+++ b/pkg/test/testharness/harness.go
@@ -31,3 +31,11 @@ func (h *Harness) TempDir() string {
 	})
 	return tmpdir
 }
+
+func (h *Harness) MustReadFile(p string) []byte {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		h.Fatalf("error from ReadFile(%q): %v", p, err)
+	}
+	return b
+}

--- a/pkg/test/testharness/harness.go
+++ b/pkg/test/testharness/harness.go
@@ -39,3 +39,14 @@ func (h *Harness) MustReadFile(p string) []byte {
 	}
 	return b
 }
+
+func (h *Harness) FileExists(p string) bool {
+	_, err := os.Stat(p)
+	if err == nil {
+		return true
+	}
+	if !os.IsNotExist(err) {
+		h.Fatalf("error from os.Stat(%q): %v", p, err)
+	}
+	return false
+}

--- a/pkg/test/testharness/harness.go
+++ b/pkg/test/testharness/harness.go
@@ -1,0 +1,33 @@
+package testharness
+
+import (
+	"os"
+	"testing"
+)
+
+type Harness struct {
+	*testing.T
+}
+
+func New(t *testing.T) *Harness {
+	h := &Harness{T: t}
+	t.Cleanup(h.Cleanup)
+	return h
+}
+
+func (h *Harness) Cleanup() {
+
+}
+
+func (h *Harness) TempDir() string {
+	tmpdir, err := os.MkdirTemp("", "test")
+	if err != nil {
+		h.Fatalf("failed to make temp directory: %v", err)
+	}
+	h.T.Cleanup(func() {
+		if err := os.RemoveAll(tmpdir); err != nil {
+			h.Errorf("error cleaning up temp directory %q: %v", tmpdir, err)
+		}
+	})
+	return tmpdir
+}


### PR DESCRIPTION
Create some golden tests to try to make sure our apply library is reasonably efficient / so we can track what it is doing.

- tests: Improve mock kubeapiserver, introduce test for direct Applier
- tests: record and validate the requests we are making
- tests: add test for when objects already exist
- tests: add test for the case when last-applied is present

