### PR TITLE
Direct applier: Avoid fetching OpenAPI

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/direct_test.go
+++ b/pkg/patterns/declarative/pkg/applier/direct_test.go
@@ -277,7 +277,8 @@ func TestDirectApplier(t *testing.T) {
 
 		t.Logf("replacing old url prefix %q", "http://"+restConfig.Host)
 		requestLog.ReplaceURLPrefix("http://"+restConfig.Host, "http://kube-apiserver")
-		requests := requestLog.FormatYAML()
+		requestLog.RemoveUserAgent()
+		requests := requestLog.FormatHTTP()
 
 		h.CompareGoldenFile(filepath.Join(testdir, "expected.yaml"), requests)
 	})

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/expected.yaml
@@ -1,79 +1,57 @@
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/api?timeout=32s
+GET http://kube-apiserver/api?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/apis?timeout=32s
+
+GET http://kube-apiserver/apis?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/api/v1?timeout=32s
+
+GET http://kube-apiserver/api/v1?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/api/v1?timeout=32s
+
+GET http://kube-apiserver/api/v1?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/com.github.proto-openapi.spec.v2@v1.0+protobuf
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/openapi/v2?timeout=32s
+
+GET http://kube-apiserver/openapi/v2?timeout=32s
+Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
+
 
 ---
-header:
-  Accept:
-  - application/json
-method: GET
-url: http://kube-apiserver/api/v1/namespaces/ns1
+
+GET http://kube-apiserver/api/v1/namespaces/ns1
+Accept: application/json
+
 
 ---
-body: |
-  {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns1\"}}\n"},"name":"ns1"}}
-header:
-  Accept:
-  - application/json
-  Content-Type:
-  - application/json
-method: POST
-url: http://kube-apiserver/api/v1/namespaces?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+
+POST http://kube-apiserver/api/v1/namespaces?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+Accept: application/json
+Content-Type: application/json
+
+{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns1\"}}\n"},"name":"ns1"}}
+
 
 ---
-header:
-  Accept:
-  - application/json
-method: GET
-url: http://kube-apiserver/api/v1/namespaces/ns2
+
+GET http://kube-apiserver/api/v1/namespaces/ns2
+Accept: application/json
+
 
 ---
-body: |
-  {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns2\"}}\n"},"name":"ns2"}}
-header:
-  Accept:
-  - application/json
-  Content-Type:
-  - application/json
-method: POST
-url: http://kube-apiserver/api/v1/namespaces?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+
+POST http://kube-apiserver/api/v1/namespaces?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+Accept: application/json
+Content-Type: application/json
+
+{"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns2\"}}\n"},"name":"ns2"}}
+

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple1/expected.yaml
@@ -22,12 +22,6 @@ Accept: application/json, */*
 
 ---
 
-GET http://kube-apiserver/openapi/v2?timeout=32s
-Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
-
-
----
-
 GET http://kube-apiserver/api/v1/namespaces/ns1
 Accept: application/json
 

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/expected.yaml
@@ -22,12 +22,6 @@ Accept: application/json, */*
 
 ---
 
-GET http://kube-apiserver/openapi/v2?timeout=32s
-Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
-
-
----
-
 GET http://kube-apiserver/api/v1/namespaces/ns1
 Accept: application/json
 

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple2/expected.yaml
@@ -1,77 +1,55 @@
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/api?timeout=32s
+GET http://kube-apiserver/api?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/apis?timeout=32s
+
+GET http://kube-apiserver/apis?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/api/v1?timeout=32s
+
+GET http://kube-apiserver/api/v1?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/api/v1?timeout=32s
+
+GET http://kube-apiserver/api/v1?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/com.github.proto-openapi.spec.v2@v1.0+protobuf
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/openapi/v2?timeout=32s
+
+GET http://kube-apiserver/openapi/v2?timeout=32s
+Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
+
 
 ---
-header:
-  Accept:
-  - application/json
-method: GET
-url: http://kube-apiserver/api/v1/namespaces/ns1
+
+GET http://kube-apiserver/api/v1/namespaces/ns1
+Accept: application/json
+
 
 ---
-body: '{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns1\"}}\n"}}}'
-header:
-  Accept:
-  - application/json
-  Content-Type:
-  - application/strategic-merge-patch+json
-method: PATCH
-url: http://kube-apiserver/api/v1/namespaces/ns1?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+
+PATCH http://kube-apiserver/api/v1/namespaces/ns1?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+Accept: application/json
+Content-Type: application/strategic-merge-patch+json
+
+{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns1\"}}\n"}}}
 
 ---
-header:
-  Accept:
-  - application/json
-method: GET
-url: http://kube-apiserver/api/v1/namespaces/ns2
+
+GET http://kube-apiserver/api/v1/namespaces/ns2
+Accept: application/json
+
 
 ---
-body: '{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns2\"}}\n"}}}'
-header:
-  Accept:
-  - application/json
-  Content-Type:
-  - application/strategic-merge-patch+json
-method: PATCH
-url: http://kube-apiserver/api/v1/namespaces/ns2?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+
+PATCH http://kube-apiserver/api/v1/namespaces/ns2?fieldManager=kubectl-client-side-apply&fieldValidation=Strict
+Accept: application/json
+Content-Type: application/strategic-merge-patch+json
+
+{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"ns2\"}}\n"}}}

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/expected.yaml
@@ -22,12 +22,6 @@ Accept: application/json, */*
 
 ---
 
-GET http://kube-apiserver/openapi/v2?timeout=32s
-Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
-
-
----
-
 GET http://kube-apiserver/api/v1/namespaces/ns1
 Accept: application/json
 

--- a/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/direct/simple3/expected.yaml
@@ -1,57 +1,39 @@
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/api?timeout=32s
+GET http://kube-apiserver/api?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/apis?timeout=32s
+
+GET http://kube-apiserver/apis?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/api/v1?timeout=32s
+
+GET http://kube-apiserver/api/v1?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/json, */*
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/api/v1?timeout=32s
+
+GET http://kube-apiserver/api/v1?timeout=32s
+Accept: application/json, */*
+
 
 ---
-header:
-  Accept:
-  - application/com.github.proto-openapi.spec.v2@v1.0+protobuf
-  User-Agent:
-  - applier.test/v0.0.0 (linux/amd64) kubernetes/$Format
-method: GET
-url: http://kube-apiserver/openapi/v2?timeout=32s
+
+GET http://kube-apiserver/openapi/v2?timeout=32s
+Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
+
 
 ---
-header:
-  Accept:
-  - application/json
-method: GET
-url: http://kube-apiserver/api/v1/namespaces/ns1
+
+GET http://kube-apiserver/api/v1/namespaces/ns1
+Accept: application/json
+
 
 ---
-header:
-  Accept:
-  - application/json
-method: GET
-url: http://kube-apiserver/api/v1/namespaces/ns2
+
+GET http://kube-apiserver/api/v1/namespaces/ns2
+Accept: application/json
+

--- a/pkg/test/httprecorder/request_log.go
+++ b/pkg/test/httprecorder/request_log.go
@@ -1,7 +1,9 @@
 package httprecorder
 
 import (
+	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -13,6 +15,27 @@ type Request struct {
 	URL    string      `json:"url,omitempty"`
 	Header http.Header `json:"header,omitempty"`
 	Body   string      `json:"body,omitempty"`
+}
+
+func (r *Request) FormatHTTP() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s %s\n", r.Method, r.URL))
+	var keys []string
+	for k := range r.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for _, v := range r.Header[k] {
+			b.WriteString(fmt.Sprintf("%s: %s\n", k, v))
+		}
+	}
+	b.WriteString("\n")
+	if r.Body != "" {
+		b.WriteString(r.Body)
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 type RequestLog struct {
@@ -31,11 +54,27 @@ func (l *RequestLog) FormatYAML() string {
 	return strings.Join(actual, "\n---\n")
 }
 
+func (l *RequestLog) FormatHTTP() string {
+	var actual []string
+	for _, request := range l.Requests {
+		s := request.FormatHTTP()
+		actual = append(actual, s)
+	}
+	return strings.Join(actual, "\n---\n\n")
+}
+
 func (l *RequestLog) ReplaceURLPrefix(old, new string) {
 	for i := range l.Requests {
 		r := &l.Requests[i]
 		if strings.HasPrefix(r.URL, old) {
 			r.URL = new + strings.TrimPrefix(r.URL, old)
 		}
+	}
+}
+
+func (l *RequestLog) RemoveUserAgent() {
+	for i := range l.Requests {
+		r := &l.Requests[i]
+		r.Header.Del("user-agent")
 	}
 }


### PR DESCRIPTION
We don't normally need it, and it is expensive to fetch.  Use ApplyOptions directly rather than going through the kubectl abstraction layer (which always fetches the OpenAPI)

Builds on #246