### PR TITLE
Log error when we can't get the GVK for an object

### DIFF
--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -573,6 +573,10 @@ func (r *Reconciler) injectOwnerRef(ctx context.Context, instance DeclarativeObj
 		}
 
 		gvk, err := apiutil.GVKForObject(owner, r.mgr.GetScheme())
+		if err != nil {
+			log.WithValues("object", o).Error(err, "unable to get GVK for object")
+			continue
+		}
 		if gvk.Group == "" || gvk.Version == "" {
 			log.WithValues("object", o).WithValues("GroupVersionKind", gvk).Info("is not valid")
 			continue


### PR DESCRIPTION
Should not be a behavioural change, but we can log a better message.
