### PR TITLE
Stop using go.mod replace directives

### DIFF
--- a/applylib/go.mod
+++ b/applylib/go.mod
@@ -2,7 +2,9 @@ module sigs.k8s.io/kubebuilder-declarative-pattern/applylib
 
 go 1.19
 
-replace sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver => ../mockkubeapiserver
+// Sometimes handy for development, but breaks usage as a library
+// Instead, please break apart commits to this module
+// replace sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver => ../mockkubeapiserver
 
 require (
 	github.com/google/go-cmp v0.5.8
@@ -11,7 +13,7 @@ require (
 	k8s.io/client-go v0.25.0
 	k8s.io/klog/v2 v2.70.1
 	sigs.k8s.io/controller-runtime v0.13.0
-	sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-00010101000000-000000000000
+	sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20221021151406-9bd3fb842119
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -30,6 +32,7 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/applylib/go.sum
+++ b/applylib/go.sum
@@ -133,6 +133,8 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
@@ -506,6 +508,8 @@ sigs.k8s.io/controller-runtime v0.13.0 h1:iqa5RNciy7ADWnIc8QxCbOX5FEKVR3uxVxKHRM
 sigs.k8s.io/controller-runtime v0.13.0/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
+sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20221021151406-9bd3fb842119 h1:PoxuR/rQXKsCp7ZJqv4sxCstjsYdn1L5pzlcoIiai/0=
+sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20221021151406-9bd3fb842119/go.mod h1:lnUjbSD3YT/lBWOZEIfhJT/uj1Ic+IRWMnT+iwsXM3Y=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/examples/guestbook-operator/go.mod
+++ b/examples/guestbook-operator/go.mod
@@ -118,7 +118,7 @@ require (
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/cli-utils v0.33.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
-	sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-00010101000000-000000000000 // indirect
+	sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20221021151406-9bd3fb842119 // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module sigs.k8s.io/kubebuilder-declarative-pattern
 
 go 1.19
 
-replace sigs.k8s.io/kubebuilder-declarative-pattern/applylib => ./applylib
-
-replace sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver => ./mockkubeapiserver
+// Sometimes handy for development, but breaks usage as a library
+// Instead, please break apart commits to this module
+// replace sigs.k8s.io/kubebuilder-declarative-pattern/applylib => ./applylib
+// replace sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver => ./mockkubeapiserver
 
 require (
 	github.com/blang/semver/v4 v4.0.0
@@ -23,8 +24,8 @@ require (
 	k8s.io/kubectl v0.25.0
 	sigs.k8s.io/cli-utils v0.33.0
 	sigs.k8s.io/controller-runtime v0.13.0
-	sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-00010101000000-000000000000
-	sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-00010101000000-000000000000
+	sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20221021151406-9bd3fb842119
+	sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20221021151406-9bd3fb842119
 	sigs.k8s.io/kustomize/api v0.12.1
 	sigs.k8s.io/kustomize/kyaml v0.13.9
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -866,6 +866,10 @@ sigs.k8s.io/controller-runtime v0.13.0 h1:iqa5RNciy7ADWnIc8QxCbOX5FEKVR3uxVxKHRM
 sigs.k8s.io/controller-runtime v0.13.0/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
+sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20221021151406-9bd3fb842119 h1:VGixuciKhhyzdZYKqUC60Kl8gxBHE9iVJOEbsPnR1pM=
+sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20221021151406-9bd3fb842119/go.mod h1:rrXMTyJJdq5vx7i7WyBTMSGICJBP7Ux25k9bKdF2Xz4=
+sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20221021151406-9bd3fb842119 h1:PoxuR/rQXKsCp7ZJqv4sxCstjsYdn1L5pzlcoIiai/0=
+sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20221021151406-9bd3fb842119/go.mod h1:lnUjbSD3YT/lBWOZEIfhJT/uj1Ic+IRWMnT+iwsXM3Y=
 sigs.k8s.io/kustomize/api v0.12.1 h1:7YM7gW3kYBwtKvoY216ZzY+8hM+lV53LUayghNRJ0vM=
 sigs.k8s.io/kustomize/api v0.12.1/go.mod h1:y3JUhimkZkR6sbLNwfJHxvo1TCLwuwm14sCYnkH6S1s=
 sigs.k8s.io/kustomize/kyaml v0.13.9 h1:Qz53EAaFFANyNgyOEJbT/yoIHygK40/ZcvU3rgry2Tk=


### PR DESCRIPTION
These make our submodules hard to consume as a library.

go.work is the latest approach that is recommended instead for local
development.

I think this does mean we will need to structure commits separately
across the libraries, but that may be acceptable.
