### PR TITLE
applylib: Recognize and map the --force kubectl option

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/applylib.go
+++ b/pkg/patterns/declarative/pkg/applier/applylib.go
@@ -28,13 +28,19 @@ func (a *ApplySetApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 		return fmt.Errorf("error parsing manifest: %w", err)
 	}
 
+	patchOptions := a.patchOptions
+
 	for _, arg := range opt.ExtraArgs {
 		switch arg {
+		case "--force":
+			opt.Force = true
 
 		default:
 			return fmt.Errorf("extraArg %q is not supported by the ApplySetApplier", arg)
 		}
 	}
+
+	patchOptions.Force = &opt.Force
 
 	dynamicClient, err := dynamic.NewForConfig(opt.RESTConfig)
 	if err != nil {
@@ -44,7 +50,7 @@ func (a *ApplySetApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 	restMapper := opt.RESTMapper
 
 	options := applyset.Options{
-		PatchOptions: a.patchOptions,
+		PatchOptions: patchOptions,
 		RESTMapper:   restMapper,
 		Client:       dynamicClient,
 	}

--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -128,7 +128,7 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 	for i, arg := range opt.ExtraArgs {
 		switch arg {
 		case "--force":
-			applyOpts.ForceConflicts = true
+			opt.Force = true
 		case "--prune":
 			applyOpts.Prune = true
 		case "--selector":
@@ -138,6 +138,7 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 		}
 	}
 
+	applyOpts.ForceConflicts = opt.Force
 	applyOpts.Namespace = opt.Namespace
 	applyOpts.SetObjects(infos)
 	applyOpts.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {

--- a/pkg/patterns/declarative/pkg/applier/exec.go
+++ b/pkg/patterns/declarative/pkg/applier/exec.go
@@ -132,6 +132,9 @@ func (c *ExecKubectl) Apply(ctx context.Context, opt ApplierOptions) error {
 		args = append(args, "--kubeconfig", f.Name())
 	}
 
+	if opt.Force {
+		args = append(args, "--force")
+	}
 	args = append(args, opt.ExtraArgs...)
 	args = append(args, "-f", "-")
 

--- a/pkg/patterns/declarative/pkg/applier/testdata/applylib/simple1/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/applylib/simple1/expected.yaml
@@ -4,7 +4,7 @@ Accept: application/json, */*
 
 ---
 
-PATCH http://kube-apiserver/api/v1/namespaces/ns1?fieldManager=kdp-test
+PATCH http://kube-apiserver/api/v1/namespaces/ns1?fieldManager=kdp-test&force=false
 Accept: application/json
 Content-Type: application/apply-patch+yaml
 
@@ -12,7 +12,7 @@ Content-Type: application/apply-patch+yaml
 
 ---
 
-PATCH http://kube-apiserver/api/v1/namespaces/ns2?fieldManager=kdp-test
+PATCH http://kube-apiserver/api/v1/namespaces/ns2?fieldManager=kdp-test&force=false
 Accept: application/json
 Content-Type: application/apply-patch+yaml
 

--- a/pkg/patterns/declarative/pkg/applier/testdata/applylib/simple2/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/applylib/simple2/expected.yaml
@@ -4,7 +4,7 @@ Accept: application/json, */*
 
 ---
 
-PATCH http://kube-apiserver/api/v1/namespaces/ns1?fieldManager=kdp-test
+PATCH http://kube-apiserver/api/v1/namespaces/ns1?fieldManager=kdp-test&force=false
 Accept: application/json
 Content-Type: application/apply-patch+yaml
 
@@ -12,7 +12,7 @@ Content-Type: application/apply-patch+yaml
 
 ---
 
-PATCH http://kube-apiserver/api/v1/namespaces/ns2?fieldManager=kdp-test
+PATCH http://kube-apiserver/api/v1/namespaces/ns2?fieldManager=kdp-test&force=false
 Accept: application/json
 Content-Type: application/apply-patch+yaml
 

--- a/pkg/patterns/declarative/pkg/applier/testdata/applylib/simple3/expected.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/applylib/simple3/expected.yaml
@@ -4,7 +4,7 @@ Accept: application/json, */*
 
 ---
 
-PATCH http://kube-apiserver/api/v1/namespaces/ns1?fieldManager=kdp-test
+PATCH http://kube-apiserver/api/v1/namespaces/ns1?fieldManager=kdp-test&force=false
 Accept: application/json
 Content-Type: application/apply-patch+yaml
 
@@ -12,7 +12,7 @@ Content-Type: application/apply-patch+yaml
 
 ---
 
-PATCH http://kube-apiserver/api/v1/namespaces/ns2?fieldManager=kdp-test
+PATCH http://kube-apiserver/api/v1/namespaces/ns2?fieldManager=kdp-test&force=false
 Accept: application/json
 Content-Type: application/apply-patch+yaml
 

--- a/pkg/patterns/declarative/pkg/applier/type.go
+++ b/pkg/patterns/declarative/pkg/applier/type.go
@@ -18,5 +18,13 @@ type ApplierOptions struct {
 	RESTMapper meta.RESTMapper
 	Namespace  string
 	Validate   bool
-	ExtraArgs  []string
+
+	// Force is set if we should "force" the apply.
+	// For server-side-apply, this corresponds to setting the force option, which ensures we take ownership
+	// even when another field manager owns a field.
+	Force bool
+
+	// ExtraArgs holds additional arguments that should be passed to kubectl.
+	// @deprecated: prefer using explicit arguments (Force etc)
+	ExtraArgs []string
 }

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -266,7 +266,7 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 	}
 	manifestStr = m
 
-	extraArgs := []string{"--force"}
+	extraArgs := []string{}
 
 	// allow user disable prune in CR
 	if p, ok := instance.(Pruner); (!ok && r.options.prune) || (ok && r.options.prune && p.Prune()) {
@@ -311,6 +311,7 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 		Manifest:   manifestStr,
 		Validate:   r.options.validate,
 		ExtraArgs:  extraArgs,
+		Force:      true,
 	}
 
 	if err := r.kubectl.Apply(ctx, applyOpt); err != nil {


### PR DESCRIPTION
We use the force option quite a lot, so we need to support it.

Also nudge away from ExtraArgs towards explicit options.
