### PR TITLE
Record event when reconciler fails unexpectedly

### DIFF
--- a/mockkubeapiserver/patchresource.go
+++ b/mockkubeapiserver/patchresource.go
@@ -101,7 +101,7 @@ func applyPatch(existing, patch map[string]interface{}) error {
 	for k, patchValue := range patch {
 		existingValue := existing[k]
 		switch patchValue := patchValue.(type) {
-		case string, int64:
+		case string, int64, float64:
 			existing[k] = patchValue
 		case map[string]interface{}:
 			if existingValue == nil {

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -179,6 +179,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	objects, err = r.reconcileExists(ctx, request.NamespacedName, instance)
 
+	if err != nil {
+		r.recorder.Eventf(instance, "Warning", "InternalError", "internal error: %v", err)
+	}
+
 	return result, err
 }
 


### PR DESCRIPTION
Otherwise it's difficult to track down what has gone wrong.

This may lead to over-eventing (if we've already recorded the error),
but we can deal with that problem when we come to it!
