### PR TITLE
Export ReconcilerOption

### DIFF
--- a/pkg/patterns/declarative/options.go
+++ b/pkg/patterns/declarative/options.go
@@ -30,12 +30,15 @@ type ManifestLoaderFunc func() (ManifestController, error)
 // DefaultManifestLoader is the manifest loader we use when a manifest loader is not otherwise configured
 var DefaultManifestLoader ManifestLoaderFunc
 
+// ReconcilerOption implements the options pattern for reconcilers
+type ReconcilerOption func(params reconcilerParams) reconcilerParams
+
 // Options are a set of reconcilerOptions applied to all controllers
 var Options struct {
 	// Begin options are applied before evaluating controller specific options
-	Begin []reconcilerOption
+	Begin []ReconcilerOption
 	// End options are applied after evaluating controller specific options
-	End []reconcilerOption
+	End []ReconcilerOption
 }
 
 type reconcilerParams struct {
@@ -80,7 +83,7 @@ type OwnerSelector = func(context.Context, DeclarativeObject, manifest.Object, m
 type LabelMaker = func(context.Context, DeclarativeObject) map[string]string
 
 // WithRawManifestOperation adds the specific ManifestOperations to the chain of manifest changes
-func WithRawManifestOperation(operations ...ManifestOperation) reconcilerOption {
+func WithRawManifestOperation(operations ...ManifestOperation) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.rawManifestOperations = append(p.rawManifestOperations, operations...)
 		return p
@@ -88,7 +91,7 @@ func WithRawManifestOperation(operations ...ManifestOperation) reconcilerOption 
 }
 
 // WithObjectTransform adds the specified ObjectTransforms to the chain of manifest changes
-func WithObjectTransform(operations ...ObjectTransform) reconcilerOption {
+func WithObjectTransform(operations ...ObjectTransform) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.objectTransformations = append(p.objectTransformations, operations...)
 		return p
@@ -96,7 +99,7 @@ func WithObjectTransform(operations ...ObjectTransform) reconcilerOption {
 }
 
 // WithManifestController overrides the default source for loading manifests
-func WithManifestController(mc ManifestController) reconcilerOption {
+func WithManifestController(mc ManifestController) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.manifestController = mc
 		return p
@@ -108,7 +111,7 @@ func WithManifestController(mc ManifestController) reconcilerOption {
 // which match a label specific to the addon instance.
 //
 // This option requires WithLabels to be used
-func WithApplyPrune() reconcilerOption {
+func WithApplyPrune() ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.prune = true
 		return p
@@ -116,7 +119,7 @@ func WithApplyPrune() reconcilerOption {
 }
 
 // WithOwner sets an owner ref on each deployed object by the OwnerSelector
-func WithOwner(ownerFn OwnerSelector) reconcilerOption {
+func WithOwner(ownerFn OwnerSelector) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.ownerFn = ownerFn
 		return p
@@ -125,7 +128,7 @@ func WithOwner(ownerFn OwnerSelector) reconcilerOption {
 
 // WithLabels sets a fixed set of labels configured provided by a LabelMaker
 // to all deployment objecs for a given DeclarativeObject
-func WithLabels(labelMaker LabelMaker) reconcilerOption {
+func WithLabels(labelMaker LabelMaker) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.labelMaker = labelMaker
 		return p
@@ -133,7 +136,7 @@ func WithLabels(labelMaker LabelMaker) reconcilerOption {
 }
 
 // WithStatus provides a Status interface that will be used during Reconcile
-func WithStatus(status Status) reconcilerOption {
+func WithStatus(status Status) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.status = status
 		return p
@@ -142,7 +145,7 @@ func WithStatus(status Status) reconcilerOption {
 
 // WithPreserveNamespace preserves the namespaces defined in the deployment manifest
 // instead of matching the namespace of the DeclarativeObject
-func WithPreserveNamespace() reconcilerOption {
+func WithPreserveNamespace() ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.preserveNamespace = true
 		return p
@@ -150,7 +153,7 @@ func WithPreserveNamespace() reconcilerOption {
 }
 
 // WithApplyKustomize run kustomize build to create final manifest
-func WithApplyKustomize() reconcilerOption {
+func WithApplyKustomize() ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.kustomize = true
 		return p
@@ -159,7 +162,7 @@ func WithApplyKustomize() reconcilerOption {
 
 // WithManagedApplication is a transform that will modify the Application object
 // in the deployment to match the configuration of the rest of the deployment.
-func WithManagedApplication(labelMaker LabelMaker) reconcilerOption {
+func WithManagedApplication(labelMaker LabelMaker) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.objectTransformations = append(p.objectTransformations, func(ctx context.Context, instance DeclarativeObject, objects *manifest.Objects) error {
 			return transformApplication(ctx, instance, objects, labelMaker)
@@ -169,7 +172,7 @@ func WithManagedApplication(labelMaker LabelMaker) reconcilerOption {
 }
 
 // WithApplyValidation enables validation with kubectl apply
-func WithApplyValidation() reconcilerOption {
+func WithApplyValidation() ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.validate = true
 		return p
@@ -177,7 +180,7 @@ func WithApplyValidation() reconcilerOption {
 }
 
 // WithApplier allows us to select a different applier strategy
-func WithApplier(applier applier.Applier) reconcilerOption {
+func WithApplier(applier applier.Applier) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.applier = applier
 		return p
@@ -200,7 +203,7 @@ func WithApplier(applier applier.Applier) reconcilerOption {
 //
 // If WithReconcileMetrics is called multiple times with same ot
 // argument, largest metricsDuration is set against that ot.
-func WithReconcileMetrics(metricsDuration int, ot *ObjectTracker) reconcilerOption {
+func WithReconcileMetrics(metricsDuration int, ot *ObjectTracker) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		var err error
 
@@ -227,5 +230,3 @@ func WithReconcileMetrics(metricsDuration int, ot *ObjectTracker) reconcilerOpti
 		return p
 	}
 }
-
-type reconcilerOption func(params reconcilerParams) reconcilerParams

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -96,7 +96,7 @@ func (e *ErrorResult) Error() string {
 // For mocking
 var defaultApplier = applier.NewDirectApplier()
 
-func (r *Reconciler) Init(mgr manager.Manager, prototype DeclarativeObject, opts ...reconcilerOption) error {
+func (r *Reconciler) Init(mgr manager.Manager, prototype DeclarativeObject, opts ...ReconcilerOption) error {
 	r.prototype = prototype
 
 	// TODO: Can we derive the name from prototype?
@@ -470,7 +470,7 @@ func (r *Reconciler) loadRawManifest(ctx context.Context, o DeclarativeObject) (
 	return s, nil
 }
 
-func (r *Reconciler) applyOptions(opts ...reconcilerOption) error {
+func (r *Reconciler) applyOptions(opts ...ReconcilerOption) error {
 	params := reconcilerParams{}
 
 	params.applier = defaultApplier


### PR DESCRIPTION
Not doing so makes it harder to build options outside of the call,
because we can't declare a []reconcilerOption unless it is exported.
