### PR TITLE
Change ApplierOptions to take Objects, not a manifest.

### DIFF
--- a/pkg/patterns/declarative/metrics_test.go
+++ b/pkg/patterns/declarative/metrics_test.go
@@ -525,7 +525,7 @@ func TestAddIfNotPresent(t *testing.T) {
 				if st.actions[i] == "Create" || st.actions[i] == "Update" {
 					var options applier.ApplierOptions
 					options.Namespace = st.defaultNamespace
-					options.Manifest = yobj
+					options.Objects = objList
 					options.RESTMapper = restMapper
 					options.RESTConfig = restConfig
 					applier := applier.NewApplySetApplier(metav1.PatchOptions{FieldManager: "kdp-test"})

--- a/pkg/patterns/declarative/pkg/applier/applylib.go
+++ b/pkg/patterns/declarative/pkg/applier/applylib.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"sigs.k8s.io/kubebuilder-declarative-pattern/applylib/applyset"
-	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
 type ApplySetApplier struct {
@@ -23,10 +22,6 @@ func NewApplySetApplier(patchOptions metav1.PatchOptions) *ApplySetApplier {
 }
 
 func (a *ApplySetApplier) Apply(ctx context.Context, opt ApplierOptions) error {
-	objects, err := manifest.ParseObjects(ctx, opt.Manifest)
-	if err != nil {
-		return fmt.Errorf("error parsing manifest: %w", err)
-	}
 
 	patchOptions := a.patchOptions
 
@@ -61,7 +56,7 @@ func (a *ApplySetApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 
 	// Populate the namespace on any namespace-scoped objects
 	if opt.Namespace != "" {
-		for _, obj := range objects.Items {
+		for _, obj := range opt.Objects {
 			gvk := obj.GroupVersionKind()
 			restMapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 			if err != nil {
@@ -81,7 +76,7 @@ func (a *ApplySetApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 	}
 
 	var applyableObjects []applyset.ApplyableObject
-	for _, obj := range objects.Items {
+	for _, obj := range opt.Objects {
 		applyableObject := obj.UnstructuredObject()
 		applyableObjects = append(applyableObjects, applyableObject)
 	}

--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/apply"
 	cmdDelete "k8s.io/kubectl/pkg/cmd/delete"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
 type DirectApplier struct {
@@ -66,12 +67,18 @@ func NewDirectApplier() Applier {
 }
 
 func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
+	objects := manifest.Objects{Items: opt.Objects}
+	manifestStr, err := objects.JSONManifest()
+	if err != nil {
+		return fmt.Errorf("error creating JSON manifest: %w", err)
+	}
+
 	ioStreams := genericclioptions.IOStreams{
 		In:     os.Stdin,
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,
 	}
-	ioReader := strings.NewReader(opt.Manifest)
+	ioReader := strings.NewReader(manifestStr)
 
 	b := d.inner.NewBuilder(opt)
 	f := d.inner.NewFactory(opt)

--- a/pkg/patterns/declarative/pkg/applier/type.go
+++ b/pkg/patterns/declarative/pkg/applier/type.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
 type Applier interface {
@@ -12,7 +13,7 @@ type Applier interface {
 }
 
 type ApplierOptions struct {
-	Manifest string
+	Objects []*manifest.Object
 
 	RESTConfig *rest.Config
 	RESTMapper meta.RESTMapper

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -255,15 +255,6 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 	}
 	objects.Items = newItems
 
-	var manifestStr string
-
-	m, err := objects.JSONManifest()
-	if err != nil {
-		log.Error(err, "creating final manifest")
-		return objects, fmt.Errorf("error creating manifest: %v", err)
-	}
-	manifestStr = m
-
 	extraArgs := []string{}
 
 	// allow user disable prune in CR
@@ -306,7 +297,7 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 		RESTConfig: r.config,
 		RESTMapper: r.restMapper,
 		Namespace:  ns,
-		Manifest:   manifestStr,
+		Objects:    objects.GetItems(),
 		Validate:   r.options.validate,
 		ExtraArgs:  extraArgs,
 		Force:      true,


### PR DESCRIPTION
In theory a breaking change, but should not break anyone and avoids
reparsing and confusion over JSON vs YAML input formats.

This fixes a bug in the new applyset applier where we were expecting YAML but getting JSON.  That applier is not the default and is only on the dev/main branch, so no backports needed, thankfully!