### PR TITLE
Add AddAnnotations companion to AddLabels

### DIFF
--- a/pkg/patterns/declarative/annotations.go
+++ b/pkg/patterns/declarative/annotations.go
@@ -11,7 +11,6 @@ import (
 func AddAnnotations(annotations map[string]string) ObjectTransform {
 	return func(ctx context.Context, o DeclarativeObject, manifest *manifest.Objects) error {
 		log := log.Log
-		// TODO: Add to selectors and labels in templates?
 		for _, o := range manifest.Items {
 			log.WithValues("object", o).WithValues("annotations", annotations).V(1).Info("add annotations to object")
 			o.AddAnnotations(annotations)

--- a/pkg/patterns/declarative/annotations.go
+++ b/pkg/patterns/declarative/annotations.go
@@ -1,0 +1,22 @@
+package declarative
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
+)
+
+// AddAnnotations returns an ObjectTransform that adds annotations to all the objects
+func AddAnnotations(annotations map[string]string) ObjectTransform {
+	return func(ctx context.Context, o DeclarativeObject, manifest *manifest.Objects) error {
+		log := log.Log
+		// TODO: Add to selectors and labels in templates?
+		for _, o := range manifest.Items {
+			log.WithValues("object", o).WithValues("annotations", annotations).V(1).Info("add annotations to object")
+			o.AddAnnotations(annotations)
+		}
+
+		return nil
+	}
+}

--- a/pkg/patterns/declarative/pkg/manifest/objects.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects.go
@@ -95,6 +95,21 @@ func (o *Object) AddLabels(labels map[string]string) {
 	o.json = nil
 }
 
+func (o *Object) AddAnnotations(annotations map[string]string) {
+	merged := make(map[string]string)
+	for k, v := range o.object.GetAnnotations() {
+		merged[k] = v
+	}
+
+	for k, v := range annotations {
+		merged[k] = v
+	}
+
+	o.object.SetAnnotations(merged)
+	// Invalidate cached json
+	o.json = nil
+}
+
 func (o *Object) GetNamespace() string {
 	return o.namespace
 }

--- a/pkg/patterns/declarative/pkg/manifest/objects_test.go
+++ b/pkg/patterns/declarative/pkg/manifest/objects_test.go
@@ -286,7 +286,7 @@ func Test_AddAnnotations(t *testing.T) {
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
+  annotations:
     app: test-app
   name: frontend
 spec:
@@ -333,7 +333,7 @@ spec:
 			}
 			for _, o := range objects.Items {
 				o.AddAnnotations(tt.inputAnnotations)
-				if len(tt.expectedAnnotations) != len(o.object.GetLabels()) {
+				if len(tt.expectedAnnotations) != len(o.object.GetAnnotations()) {
 					t.Errorf("Expected length of labels to be %v but is %v", len(tt.expectedAnnotations), len(o.object.GetAnnotations()))
 				}
 				if diff := cmp.Diff(tt.expectedAnnotations, o.object.GetAnnotations()); diff != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

I had a use case for setting annotations on all objects in an object transform, and found that while we do have `AddLabels` that does this, there's no corresponding `AddAnnotations`.

There _is_ a way to do this without this PR, since the `manifest.Object` exposes `UnstructuredObject()` to get at the underlying `unstructured.Unstructured`, but its docstring states

> UnstructuredContent exposes the raw object, primarily for testing

so I figured it's better to not ask users to take a dependency on that.
