### PR TITLE
Set Overwrite in ApplyOptions

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -134,6 +134,9 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 		ValidationDirective: metav1.FieldValidationStrict,
 		Mapper:              opt.RESTMapper,
 		DynamicClient:       dynamicClient,
+
+		// Automatically resolve conflicts between the modified and live configuration by using values from the modified configuration
+		Overwrite: true,
 	}
 	// TODO this will add the print part at all times.
 	applyOpts.PostProcessorFn = applyOpts.PrintAndPrunePostProcessor()


### PR DESCRIPTION
We lost the default value in #247, which is a regression that prevents
some changes from going through.