### PR TITLE
Replace deprecated funcs on ioutil package

### DIFF
--- a/applylib/testutils/harness.go
+++ b/applylib/testutils/harness.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -205,12 +204,12 @@ func (h *Harness) RESTMapper() *restmapper.DeferredDiscoveryRESTMapper {
 func (h *Harness) AssertMatchesFile(p string, got string) {
 	if os.Getenv("WRITE_GOLDEN_OUTPUT") != "" {
 		// Short-circuit when the output is correct
-		b, err := ioutil.ReadFile(p)
+		b, err := os.ReadFile(p)
 		if err == nil && bytes.Equal(b, []byte(got)) {
 			return
 		}
 
-		if err := ioutil.WriteFile(p, []byte(got), 0644); err != nil {
+		if err := os.WriteFile(p, []byte(got), 0644); err != nil {
 			h.Fatalf("failed to write golden output %s: %v", p, err)
 		}
 		h.Errorf("wrote output to %s", p)

--- a/mockkubeapiserver/patchresource.go
+++ b/mockkubeapiserver/patchresource.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -53,7 +53,7 @@ func (req *patchResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
 		existingObj = nil
 	}
 
-	bodyBytes, err := ioutil.ReadAll(req.r.Body)
+	bodyBytes, err := io.ReadAll(req.r.Body)
 	if err != nil {
 		return err
 	}

--- a/mockkubeapiserver/postresource.go
+++ b/mockkubeapiserver/postresource.go
@@ -19,7 +19,7 @@ package mockkubeapiserver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -48,7 +48,7 @@ func (req *postResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
 		return req.writeErrorResponse(http.StatusNotFound)
 	}
 
-	bodyBytes, err := ioutil.ReadAll(req.r.Body)
+	bodyBytes, err := io.ReadAll(req.r.Body)
 	if err != nil {
 		return err
 	}

--- a/mockkubeapiserver/putresource.go
+++ b/mockkubeapiserver/putresource.go
@@ -19,7 +19,7 @@ package mockkubeapiserver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 
@@ -52,7 +52,7 @@ func (req *putResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
 		return req.writeErrorResponse(http.StatusNotFound)
 	}
 
-	bodyBytes, err := ioutil.ReadAll(req.r.Body)
+	bodyBytes, err := io.ReadAll(req.r.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/patterns/declarative/pkg/applier/applylib_test.go
+++ b/pkg/patterns/declarative/pkg/applier/applylib_test.go
@@ -3,7 +3,7 @@ package applier
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -125,12 +125,12 @@ func (h *logKubeRequestsHook) BeforeHTTPOperation(op *mockkubeapiserver.HTTPOper
 	}
 
 	if req.Body != nil {
-		requestBody, err := ioutil.ReadAll(req.Body)
+		requestBody, err := io.ReadAll(req.Body)
 		if err != nil {
 			panic("failed to read request body")
 		}
 		entry.Request.Body = string(requestBody)
-		req.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
+		req.Body = io.NopCloser(bytes.NewReader(requestBody))
 	}
 	h.log.Entries = append(h.log.Entries, entry)
 }

--- a/pkg/patterns/declarative/pkg/applier/exec.go
+++ b/pkg/patterns/declarative/pkg/applier/exec.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -117,7 +116,7 @@ func (c *ExecKubectl) Apply(ctx context.Context, opt ApplierOptions) error {
 			return fmt.Errorf("error building kubeconfig: %w", err)
 		}
 
-		f, err := ioutil.TempFile("", "kubeconfig")
+		f, err := os.CreateTemp("", "kubeconfig")
 		if err != nil {
 			return fmt.Errorf("error creating temp file: %w", err)
 		}

--- a/pkg/test/httprecorder/http_recorder.go
+++ b/pkg/test/httprecorder/http_recorder.go
@@ -3,7 +3,7 @@ package httprecorder
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -27,12 +27,12 @@ func (m *HTTPRecorder) RoundTrip(request *http.Request) (*http.Response, error) 
 	}
 
 	if request.Body != nil {
-		requestBody, err := ioutil.ReadAll(request.Body)
+		requestBody, err := io.ReadAll(request.Body)
 		if err != nil {
 			panic("failed to read request body")
 		}
 		entry.Request.Body = string(requestBody)
-		request.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
+		request.Body = io.NopCloser(bytes.NewReader(requestBody))
 	}
 
 	response, err := m.inner.RoundTrip(request)
@@ -54,12 +54,12 @@ func (m *HTTPRecorder) RoundTrip(request *http.Request) (*http.Response, error) 
 		}
 
 		if response.Body != nil {
-			requestBody, err := ioutil.ReadAll(response.Body)
+			requestBody, err := io.ReadAll(response.Body)
 			if err != nil {
 				entry.Response.Body = fmt.Sprintf("<error reading response:%v>", err)
 			} else {
 				entry.Response.Body = string(requestBody)
-				response.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
+				response.Body = io.NopCloser(bytes.NewReader(requestBody))
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
As of Go 1.16, funcs related to operate files and directories in [the ioutil pakage are deprecated](https://pkg.go.dev/io/ioutil).
This PR replaces deprecated funcs on ioutil by using io and os packages.

/kind cleanup

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Additional documentation**:
NONE
