### PR TITLE
add option to configure cascading strategy

### DIFF
--- a/pkg/patterns/declarative/options.go
+++ b/pkg/patterns/declarative/options.go
@@ -19,6 +19,8 @@ package declarative
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/applier"
@@ -48,6 +50,7 @@ type reconcilerParams struct {
 
 	applier applier.Applier
 
+	cascadingStrategy metav1.DeletionPropagation
 	prune             bool
 	preserveNamespace bool
 	kustomize         bool
@@ -183,6 +186,14 @@ func WithApplyValidation() ReconcilerOption {
 func WithApplier(applier applier.Applier) ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
 		p.applier = applier
+		return p
+	}
+}
+
+// WithCascadingStrategy allows us to select a different CascadingStrategy, which ultimately sets the PropagationPolicy
+func WithCascadingStrategy(cs metav1.DeletionPropagation) ReconcilerOption {
+	return func(p reconcilerParams) reconcilerParams {
+		p.cascadingStrategy = cs
 		return p
 	}
 }

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -294,15 +294,14 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 	}
 
 	applierOpt := applier.ApplierOptions{
-		RESTConfig: r.config,
-		RESTMapper: r.restMapper,
-		Namespace:  ns,
-		Objects:    objects.GetItems(),
-		Validate:   r.options.validate,
-		ExtraArgs:  extraArgs,
-		Force:      true,
-		// TODO Make this configurable
-		CascadingStrategy: "Foreground",
+		RESTConfig:        r.config,
+		RESTMapper:        r.restMapper,
+		Namespace:         ns,
+		Objects:           objects.GetItems(),
+		Validate:          r.options.validate,
+		ExtraArgs:         extraArgs,
+		Force:             true,
+		CascadingStrategy: r.options.cascadingStrategy,
 	}
 
 	applier := r.options.applier
@@ -482,6 +481,10 @@ func (r *Reconciler) applyOptions(opts ...ReconcilerOption) error {
 			return err
 		}
 		params.manifestController = loader
+	}
+
+	if params.cascadingStrategy == "" {
+		params.cascadingStrategy = "Foreground"
 	}
 
 	r.options = params


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
This PR makes the CascadingStrategy added in https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/pull/274 configurable, adding a new option `withCascadingStrategy` and making sure that `Foreground` is the default if not set.

**Which issue(s) this PR fixes**:
We need it to configure different CascadingStrategies for main and test
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
I have not seen proper tests I could test this with. Are there some?
I ran this with the controller I am working on.

**Additional documentation**:

