### PR TITLE
mockkubeapiserver: support PartialObjectMetadata watches

### DIFF
--- a/mockkubeapiserver/listresource.go
+++ b/mockkubeapiserver/listresource.go
@@ -19,8 +19,11 @@ package mockkubeapiserver
 import (
 	"context"
 	"net/http"
+	"strings"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 )
@@ -46,9 +49,16 @@ func (req *listResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
 
 	query := req.r.URL.Query()
 
+	// TODO: we should parse the accept header correctly
+	partialObjectMetadata := false
+	accept := req.r.Header.Get("accept")
+	if strings.Contains(accept, "PartialObjectMetadata") {
+		partialObjectMetadata = true
+	}
+
 	watchParam := query.Get("watch")
 	if watchParam == "true" {
-		return req.doWatch(ctx, s, resource)
+		return req.doWatch(ctx, s, resource, partialObjectMetadata)
 	}
 
 	var filter ListFilter
@@ -64,29 +74,45 @@ func (req *listResource) Run(ctx context.Context, s *MockKubeAPIServer) error {
 }
 
 type watchEvent struct {
-	Message messageV1
-	JSON    []byte
+	internalObject *unstructured.Unstructured
+	eventType      string
 
 	Namespace string
+
+	mutex                     sync.Mutex
+	partialObjectMetadataJSON []byte
+	json                      []byte
 }
 
 type messageV1 struct {
-	Type   string                     `json:"type"`
-	Object *unstructured.Unstructured `json:"object"`
+	Type   string         `json:"type"`
+	Object runtime.Object `json:"object"`
 }
 
-func (req *listResource) doWatch(ctx context.Context, s *MockKubeAPIServer, resource *ResourceInfo) error {
+func (req *listResource) doWatch(ctx context.Context, s *MockKubeAPIServer, resource *ResourceInfo, partialObjectMetadata bool) error {
 	w := req.w
-	w.Header().Add("Content-Type", "application/json")
+
+	contentType := "application/json"
+	if partialObjectMetadata {
+		contentType = "application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1"
+	}
+
+	w.Header().Add("Content-Type", contentType)
 	w.Header().Add("Cache-Control", "no-cache, private")
 
 	var opt WatchOptions
 	opt.Namespace = req.Namespace
 
 	return s.storage.Watch(ctx, resource, opt, func(ev *watchEvent) error {
-		klog.Infof("sending watch event %s", string(ev.JSON))
-		if _, err := w.Write(ev.JSON); err != nil {
-			return err
+		klog.V(2).Infof("sending watch event %s", string(ev.JSON()))
+		if partialObjectMetadata {
+			if _, err := w.Write(ev.PartialObjectMetadataJSON()); err != nil {
+				return err
+			}
+		} else {
+			if _, err := w.Write(ev.JSON()); err != nil {
+				return err
+			}
 		}
 		// TODO: Should we try to debounce flushes?  We could have a queue and send everything in the queue before flushing
 		if f, ok := w.(http.Flusher); ok {


### PR DESCRIPTION
controller-runtime seems to have some bugs around apiservers that
don't support this, so introduce a minimal implementation.
