### PR TITLE
tests: normalize http request order

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/applylib_test.go
+++ b/pkg/patterns/declarative/pkg/applier/applylib_test.go
@@ -94,6 +94,8 @@ func runApplierGoldenTests(t *testing.T, testDir string, interceptHTTPServer boo
 		t.Logf("replacing old url prefix %q", "http://"+restConfig.Host)
 		requestLog.ReplaceURLPrefix("http://"+restConfig.Host, "http://kube-apiserver")
 		requestLog.RemoveUserAgent()
+		requestLog.SortGETs()
+
 		requests := requestLog.FormatHTTP()
 		h.CompareGoldenFile(filepath.Join(testdir, "expected.yaml"), requests)
 
@@ -101,6 +103,7 @@ func runApplierGoldenTests(t *testing.T, testDir string, interceptHTTPServer boo
 			t.Logf("replacing old url prefix %q", "http://"+restConfig.Host)
 			apiserverRequestLog.ReplaceURLPrefix("http://"+restConfig.Host, "http://kube-apiserver")
 			apiserverRequestLog.RemoveUserAgent()
+			apiserverRequestLog.SortGETs()
 			apiserverRequestLog.RemoveHeader("Kubectl-Session")
 			apiserverRequests := apiserverRequestLog.FormatHTTP()
 			h.CompareGoldenFile(filepath.Join(testdir, "expected-apiserver.yaml"), apiserverRequests)

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple1/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple1/expected-apiserver.yaml
@@ -18,27 +18,27 @@ Kubectl-Command: kubectl apply
 
 ---
 
+GET /api/v1?timeout=32s
+Accept: application/json, */*
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+
+---
+
+GET /api/v1?timeout=32s
+Accept: application/json, */*
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+
+---
+
 GET /apis?timeout=32s
-Accept: application/json, */*
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
-
----
-
-GET /api/v1?timeout=32s
-Accept: application/json, */*
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
-
----
-
-GET /api/v1?timeout=32s
 Accept: application/json, */*
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple2/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple2/expected-apiserver.yaml
@@ -18,27 +18,27 @@ Kubectl-Command: kubectl apply
 
 ---
 
+GET /api/v1?timeout=32s
+Accept: application/json, */*
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+
+---
+
+GET /api/v1?timeout=32s
+Accept: application/json, */*
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+
+---
+
 GET /apis?timeout=32s
-Accept: application/json, */*
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
-
----
-
-GET /api/v1?timeout=32s
-Accept: application/json, */*
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
-
----
-
-GET /api/v1?timeout=32s
 Accept: application/json, */*
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple3/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple3/expected-apiserver.yaml
@@ -18,27 +18,27 @@ Kubectl-Command: kubectl apply
 
 ---
 
+GET /api/v1?timeout=32s
+Accept: application/json, */*
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+
+---
+
+GET /api/v1?timeout=32s
+Accept: application/json, */*
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+
+---
+
 GET /apis?timeout=32s
-Accept: application/json, */*
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
-
----
-
-GET /api/v1?timeout=32s
-Accept: application/json, */*
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
-
----
-
-GET /api/v1?timeout=32s
 Accept: application/json, */*
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply


### PR DESCRIPTION
To avoid spurious failures from concurrent requests, we sort
consecutive API discovery requests alphabetically.
