### PR TITLE
tests: update expected test output for the latest kubectl version

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple1/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple1/expected-apiserver.yaml
@@ -9,7 +9,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /api?timeout=32s
-Accept: application/json, */*
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -19,7 +19,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /apis?timeout=32s
-Accept: application/json, */*
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -28,7 +28,7 @@ Kubectl-Command: kubectl apply
 
 ---
 
-GET /api/v1?timeout=32s
+GET /apis/v1?timeout=32s
 Accept: application/json, */*
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple2/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple2/expected-apiserver.yaml
@@ -9,7 +9,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /api?timeout=32s
-Accept: application/json, */*
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -19,7 +19,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /apis?timeout=32s
-Accept: application/json, */*
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -28,7 +28,7 @@ Kubectl-Command: kubectl apply
 
 ---
 
-GET /api/v1?timeout=32s
+GET /apis/v1?timeout=32s
 Accept: application/json, */*
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple3/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple3/expected-apiserver.yaml
@@ -9,7 +9,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /api?timeout=32s
-Accept: application/json, */*
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -19,7 +19,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /apis?timeout=32s
-Accept: application/json, */*
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -28,7 +28,7 @@ Kubectl-Command: kubectl apply
 
 ---
 
-GET /api/v1?timeout=32s
+GET /apis/v1?timeout=32s
 Accept: application/json, */*
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply


### PR DESCRIPTION
We get the kubectl version from our runner pod, and it has been
updated to a newer version that sends a new Accept header.

Update the golden output to expect that.

We probably should run with a known version of kubectl (or skip the
test if the version is not correct), but first step is at least to
match what we have.
