### PR TITLE
tests: run with a known version of kubectl

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,1 @@
+kubectl

--- a/dev/update-golden
+++ b/dev/update-golden
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# CI script to run tests in the mode where they write the golden output files
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# cd to the repo root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+
+# Ensure we run with a known version of kubectl
+if [[ ! -f "bin/kubectl" ]]; then
+  echo "Downloading kubectl to bin/kubectl"
+  mkdir -p bin/
+  curl -L -o bin/kubectl https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl
+fi
+chmod +x bin/kubectl
+export PATH="${REPO_ROOT}/bin:$PATH"
+echo "kubectl version is $(kubectl version --client)"
+
+WRITE_GOLDEN_OUTPUT=1 go test -count=1 -v ./...

--- a/hack/ci/test.sh
+++ b/hack/ci/test.sh
@@ -24,10 +24,22 @@ REPO_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${CI_ROOT}/fetch_kubebuilder_release_bin.sh"
 
 cd "${REPO_ROOT}"
+# Make sure REPO_ROOT is an absolute path
+REPO_ROOT=$(pwd)
+
+# Ensure we run with a known version of kubectl
+if [[ ! -f "bin/kubectl" ]]; then
+  echo "Downloading kubectl to bin/kubectl"
+  mkdir -p bin/
+  curl -L -o bin/kubectl https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl
+fi
+chmod +x bin/kubectl
+export PATH="${REPO_ROOT}/bin:$PATH"
+echo "kubectl version is $(kubectl version --client)"
 
 export GO111MODULE=on
 
-go test sigs.k8s.io/kubebuilder-declarative-pattern/pkg/...
+go test -v -count=1 sigs.k8s.io/kubebuilder-declarative-pattern/pkg/...
 
 cd examples/guestbook-operator
 go test sigs.k8s.io/kubebuilder-declarative-pattern/examples/guestbook-operator/controllers/...

--- a/pkg/patterns/declarative/pkg/applier/exec_test.go
+++ b/pkg/patterns/declarative/pkg/applier/exec_test.go
@@ -144,6 +144,18 @@ metadata:
 }
 
 func TestKubectlApplier(t *testing.T) {
+	kubectlPath, err := exec.LookPath("kubectl")
+	if err != nil {
+		t.Fatalf("failed to find kubectl on path: %v", err)
+	}
+	t.Logf("kubectl found at %q", kubectlPath)
+
+	kubectlVersion, err := exec.Command("kubectl", "version", "--client").CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run kubectl version: %v", err)
+	}
+	t.Logf("kubectl version is %q", kubectlVersion)
+
 	applier := NewExec()
 	runApplierGoldenTests(t, "testdata/kubectl", true, applier)
 }

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple1/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple1/expected-apiserver.yaml
@@ -9,17 +9,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /api?timeout=32s
-Accept: application/json, */*
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
-
----
-
-GET /api/v1?timeout=32s
-Accept: application/json, */*
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -39,6 +29,16 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /apis?timeout=32s
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+
+---
+
+GET /apis/v1?timeout=32s
 Accept: application/json, */*
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple2/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple2/expected-apiserver.yaml
@@ -9,17 +9,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /api?timeout=32s
-Accept: application/json, */*
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
-
----
-
-GET /api/v1?timeout=32s
-Accept: application/json, */*
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -39,6 +29,16 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /apis?timeout=32s
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+
+---
+
+GET /apis/v1?timeout=32s
 Accept: application/json, */*
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple3/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple3/expected-apiserver.yaml
@@ -9,17 +9,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /api?timeout=32s
-Accept: application/json, */*
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
-
----
-
-GET /api/v1?timeout=32s
-Accept: application/json, */*
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -39,6 +29,16 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /apis?timeout=32s
+Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+
+---
+
+GET /apis/v1?timeout=32s
 Accept: application/json, */*
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply


### PR DESCRIPTION
Update hack/ci/test.sh to download kubectl and add it to the path.

Add dev/update-golden to generate golden output with the kubectl version.

We run with kubectl 1.26 so that we get the fast-discovery, as this is
expected to roll out more generally over the next few months.
