### PR TITLE
Update README about required go version

### DIFF
--- a/docs/addon/walkthrough/README.md
+++ b/docs/addon/walkthrough/README.md
@@ -10,7 +10,7 @@ Install the following depenencies:
 - [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (tested with v3.8.7)
 - docker
 - kubectl
-- golang (>=1.11 for go modules)
+- golang (1.13 <= version < 1.17 for go modules)
 
 Create a new directory and use kubebuilder to scaffold the operator:
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:

```
2023/01/04 15:52:14 failed to initialize project: unable to run pre-scaffold tasks of "base.go.kubebuilder.io/v3": go version 'go1.17' is incompatible because 'requires 1.13 <= version < 1.17'. You can skip this check using the --skip-go-version-check flag
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

