### PR TITLE
make kustomize hydration a no-op

### DIFF
--- a/examples/guestbook-operator/channels/packages/guestbook/0.1.0/kustomization.yaml
+++ b/examples/guestbook-operator/channels/packages/guestbook/0.1.0/kustomization.yaml
@@ -1,2 +1,0 @@
-resources:
-- manifest.yaml

--- a/examples/guestbook-operator/controllers/guestbook_controller.go
+++ b/examples/guestbook-operator/controllers/guestbook_controller.go
@@ -59,8 +59,6 @@ func (r *GuestbookReconciler) setupReconciler(mgr ctrl.Manager) error {
 		declarative.WithStatus(status.NewBasic(mgr.GetClient())),
 		declarative.WithApplyPrune(),
 		declarative.WithObjectTransform(addon.ApplyPatches),
-		declarative.WithApplyKustomize(),
-
 		// Add other optional options for testing
 		declarative.WithApplyValidation(),
 		declarative.WithReconcileMetrics(0, nil),

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/kubebuilder-declarative-pattern/applylib v0.0.0-20221111030210-e034bc5469a5
 	sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver v0.0.0-20221111030210-e034bc5469a5
-	sigs.k8s.io/kustomize/api v0.12.1
 	sigs.k8s.io/kustomize/kyaml v0.13.9
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -112,5 +111,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
+	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/pkg/patterns/declarative/options.go
+++ b/pkg/patterns/declarative/options.go
@@ -50,7 +50,6 @@ type reconcilerParams struct {
 
 	prune             bool
 	preserveNamespace bool
-	kustomize         bool
 	validate          bool
 	metrics           bool
 
@@ -153,9 +152,9 @@ func WithPreserveNamespace() ReconcilerOption {
 }
 
 // WithApplyKustomize run kustomize build to create final manifest
+// Deprecated: Kustomize hydration is no longer supported, please use WithObjectTransform.
 func WithApplyKustomize() ReconcilerOption {
 	return func(p reconcilerParams) reconcilerParams {
-		p.kustomize = true
 		return p
 	}
 }

--- a/reconciler-options.md
+++ b/reconciler-options.md
@@ -37,9 +37,6 @@ WithStatus provides a (Status)[https://github.com/kubernetes-sigs/kubebuilder-de
 WithPreserveNamespace preserves the namespaces defined in the deployment manifest
 instead of matching the namespace of the DeclarativeObject
 
-## WithApplyKustomize
-WithApplyKustomize run kustomize build to create final manifest
-
 ## WithManagedApplication
 WithManagedApplication is a transform that will modify the Application object in the deployment to match the configuration of the rest of the deployment.
 


### PR DESCRIPTION
This PR is aimed at downgrade the kustomize usage in k-d-p, which itself can potentially cause issues on imports and for other feature extension.

TODO: We'd like to use a build constraint to not deprecate methods. I'll work on that later once I get time.