### PR TITLE
[WIP] Add go tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,3 +77,16 @@ jobs:
         kubectl get nodes -o wide
         kubectl get pods --all-namespaces -o wide
         kubectl get services --all-namespaces -o wide
+
+  go-test:
+    strategy:
+      matrix:
+        go-version: [1.18.x, 1.19.x]
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/checkout@v3
+      - run: go test ./...


### PR DESCRIPTION
I think the testdata is out of date when we modify [the requestlog logic](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/pull/287)

I also added a github action to verify these tests always run in the CI. 


