### PR TITLE
Normalize more discovery requests

### DIFF
--- a/pkg/test/httprecorder/request_log.go
+++ b/pkg/test/httprecorder/request_log.go
@@ -123,6 +123,11 @@ func (l *RequestLog) SortGETs() {
 		switch u.Path {
 		case "/apis", "/api/v1", "/apis/v1":
 			return u.Path, true
+		default:
+			tokens := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+			if len(tokens) == 3 && tokens[0] == "apis" {
+				return u.Path, true
+			}
 		}
 		return "", false
 	}

--- a/pkg/test/testreconciler/simpletest/controller_test.go
+++ b/pkg/test/testreconciler/simpletest/controller_test.go
@@ -142,6 +142,7 @@ func testSimpleReconciler(h *testharness.Harness, testdir string, applier applie
 	h.Logf("replacing old url prefix %q", "http://"+restConfig.Host)
 	requestLog.ReplaceURLPrefix("http://"+restConfig.Host, "http://kube-apiserver")
 	requestLog.RemoveUserAgent()
+	requestLog.SortGETs()
 	// Workaround for non-determinism in https://github.com/kubernetes/kubernetes/blob/79a62d62350fb600f97d1f6309c3274515b3587a/staging/src/k8s.io/client-go/tools/cache/reflector.go#L301
 	requestLog.RegexReplaceURL("&timeoutSeconds=.*&", "&timeoutSeconds=<replaced>&")
 


### PR DESCRIPTION
We recognize (and sort) more group-discovery requests - now that we
have them - so that golden test output can tolerate parallel/random
discovery as done by kubectl.
