### PR TITLE
kubectl applier: use an empty cache dir in testing

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/applylib_test.go
+++ b/pkg/patterns/declarative/pkg/applier/applylib_test.go
@@ -22,11 +22,13 @@ import (
 
 func TestApplySetApplier(t *testing.T) {
 	patchOptions := metav1.PatchOptions{FieldManager: "kdp-test"}
-	applier := NewApplySetApplier(patchOptions)
-	runApplierGoldenTests(t, "testdata/applylib", false, applier)
+	applierFn := func() Applier {
+		return NewApplySetApplier(patchOptions)
+	}
+	runApplierGoldenTests(t, "testdata/applylib", false, applierFn)
 }
 
-func runApplierGoldenTests(t *testing.T, testDir string, interceptHTTPServer bool, applier Applier) {
+func runApplierGoldenTests(t *testing.T, testDir string, interceptHTTPServer bool, applierFn func() Applier) {
 	testharness.RunGoldenTests(t, testDir, func(h *testharness.Harness, testdir string) {
 		ctx := context.Background()
 
@@ -87,6 +89,7 @@ func runApplierGoldenTests(t *testing.T, testDir string, interceptHTTPServer boo
 			RESTConfig: restConfig,
 			RESTMapper: restMapper,
 		}
+		applier := applierFn()
 		if err := applier.Apply(ctx, options); err != nil {
 			t.Fatalf("error from applier.Apply: %v", err)
 		}

--- a/pkg/patterns/declarative/pkg/applier/direct_test.go
+++ b/pkg/patterns/declarative/pkg/applier/direct_test.go
@@ -218,6 +218,6 @@ metadata:
 }
 
 func TestDirectApplier(t *testing.T) {
-	applier := NewDirectApplier()
-	runApplierGoldenTests(t, "testdata/direct", false, applier)
+	applierFn := NewDirectApplier
+	runApplierGoldenTests(t, "testdata/direct", false, applierFn)
 }


### PR DESCRIPTION
This ensures that we don't reuse the discovery data from a previous
run, if we happen to land on the same port etc.
