### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/examples/guestbook-operator/channels/packages/guestbook/0.1.0/manifest.yaml
+++ b/examples/guestbook-operator/channels/packages/guestbook/0.1.0/manifest.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: k8s.gcr.io/redis:e2e  # or just image: redis
+        image: registry.k8s.io/redis:e2e  # or just image: redis
         resources:
           requests:
             cpu: 100m

--- a/examples/guestbook-operator/controllers/tests/patches-stable.out.yaml
+++ b/examples/guestbook-operator/controllers/tests/patches-stable.out.yaml
@@ -54,7 +54,7 @@ spec:
         tier: backend
     spec:
       containers:
-      - image: k8s.gcr.io/redis:e2e
+      - image: registry.k8s.io/redis:e2e
         name: master
         ports:
         - containerPort: 6379

--- a/examples/guestbook-operator/controllers/tests/simple-stable.out.yaml
+++ b/examples/guestbook-operator/controllers/tests/simple-stable.out.yaml
@@ -54,7 +54,7 @@ spec:
         tier: backend
     spec:
       containers:
-      - image: k8s.gcr.io/redis:e2e
+      - image: registry.k8s.io/redis:e2e
         name: master
         ports:
         - containerPort: 6379


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR replaces all `k8s.gcr.io` references with `registry.k8s.io`. See the linked issue for more details.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/k8s.io/issues/4738

**Release note**:
```
Replace all `k8s.gcr.io` references with `registry.k8s.io`
```