### PR TITLE
testreconciler: pause after reconciliation

### DIFF
--- a/pkg/patterns/declarative/hooks.go
+++ b/pkg/patterns/declarative/hooks.go
@@ -48,3 +48,19 @@ type AfterApply interface {
 type BeforeApply interface {
 	BeforeApply(ctx context.Context, op *ApplyOperation) error
 }
+
+// UpdateStatusOperation contains the details of an Apply operation
+type UpdateStatusOperation struct {
+	// Subject is the object we are reconciling
+	Subject DeclarativeObject
+}
+
+// AfterUpdateStatus is implemented by hooks that want to be called after the update-status phase
+type AfterUpdateStatus interface {
+	AfterUpdateStatus(ctx context.Context, op *UpdateStatusOperation) error
+}
+
+// BeforeUpdateStatus is implemented by hooks that want to be called before the update-status phase
+type BeforeUpdateStatus interface {
+	BeforeUpdateStatus(ctx context.Context, op *UpdateStatusOperation) error
+}


### PR DESCRIPTION
We sleep briefly (100ms) after updating the status.

This is a hack to ensure that we see the watch event, because
otherwise we can start a re-reconcile based on our derived objects,
and then reconcile again based on our own status update.

This is racy behaviour and causes non-determinism which breaks our
golden tests.

We do this only in this test controller, but maybe we should have
similar logic to "debounce" in all controllers.

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

