### PR TITLE
tests: fix race when recording concurrent requests

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/applylib_test.go
+++ b/pkg/patterns/declarative/pkg/applier/applylib_test.go
@@ -135,5 +135,5 @@ func (h *logKubeRequestsHook) BeforeHTTPOperation(op *mockkubeapiserver.HTTPOper
 		entry.Request.Body = string(requestBody)
 		req.Body = io.NopCloser(bytes.NewReader(requestBody))
 	}
-	h.log.Entries = append(h.log.Entries, entry)
+	h.log.AddEntry(entry)
 }

--- a/pkg/test/httprecorder/http_recorder.go
+++ b/pkg/test/httprecorder/http_recorder.go
@@ -41,7 +41,7 @@ func (m *HTTPRecorder) RoundTrip(request *http.Request) (*http.Response, error) 
 	}
 
 	// We log the request here, because otherwise we miss long-running requests (watches)
-	m.log.Entries = append(m.log.Entries, entry)
+	m.log.AddEntry(entry)
 
 	response, err := m.inner.RoundTrip(request)
 


### PR DESCRIPTION
When kubectl was doing discovery in parallel, we would often drop
requests from the log.  Add a mutex to protect against this (and
generally to make it more correct)
