### PR TITLE
fix: use apply set tooling in apply set applier

### DIFF
--- a/applylib/applyset/applyset.go
+++ b/applylib/applyset/applyset.go
@@ -95,6 +95,8 @@ func New(options Options) (*ApplySet, error) {
 	parent := options.Parent
 	parentRef := &kubectlapply.ApplySetParentRef{Name: parent.Name(), Namespace: parent.Namespace(), RESTMapping: parent.RESTMapping()}
 
+	// The tooling string slash cutting is to support the ApplySetTooling struct that kubectlapply.NewApplySet() expects.
+	// For instance, 'kpt/v1.0.0' will map to ApplySetTooling{Name: "kpt", Version: "v1.0.0"}.
 	toolName, toolVersion, _ := strings.Cut(options.Tooling, "/")
 	if toolName == "" {
 		toolName = parent.GetSubject().GetObjectKind().GroupVersionKind().Kind

--- a/applylib/applyset/applyset.go
+++ b/applylib/applyset/applyset.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -71,7 +70,7 @@ type ApplySet struct {
 	// deployment manifests.
 	parent Parent
 	// If not given, the tooling value will be the `Parent` Kind.
-	tooling kubectlapply.ApplySetTooling
+	tooling string
 }
 
 // Options holds the parameters for building an ApplySet.
@@ -94,16 +93,7 @@ type Options struct {
 func New(options Options) (*ApplySet, error) {
 	parent := options.Parent
 	parentRef := &kubectlapply.ApplySetParentRef{Name: parent.Name(), Namespace: parent.Namespace(), RESTMapping: parent.RESTMapping()}
-
-	// The tooling string slash cutting is to support the ApplySetTooling struct that kubectlapply.NewApplySet() expects.
-	// For instance, 'kpt/v1.0.0' will map to ApplySetTooling{Name: "kpt", Version: "v1.0.0"}.
-	toolName, toolVersion, _ := strings.Cut(options.Tooling, "/")
-	if toolName == "" {
-		toolName = parent.GetSubject().GetObjectKind().GroupVersionKind().Kind
-	}
-	tooling := kubectlapply.ApplySetTooling{Name: toolName, Version: toolVersion}
-
-	kapplyset := kubectlapply.NewApplySet(parentRef, tooling, options.RESTMapper)
+	kapplyset := kubectlapply.NewApplySet(parentRef, kubectlapply.ApplySetTooling{Name: options.Tooling}, options.RESTMapper)
 	if options.PatchOptions.FieldManager == "" {
 		options.PatchOptions.FieldManager = kapplyset.FieldManager()
 	}
@@ -115,7 +105,7 @@ func New(options Options) (*ApplySet, error) {
 		deleteOptions: options.DeleteOptions,
 		prune:         options.Prune,
 		parent:        parent,
-		tooling:       tooling,
+		tooling:       options.Tooling,
 	}
 	a.trackers = &objectTrackerList{}
 	return a, nil
@@ -159,7 +149,7 @@ func (a *ApplySet) ApplyOnce(ctx context.Context) (*ApplyResults, error) {
 	// single actuation and not for reconciliation.
 	// Note: The Kubectl ApplySet will share the RESTMapper with k-d-p/ApplySet, which caches all the manifests in the past.
 	parentRef := &kubectlapply.ApplySetParentRef{Name: a.parent.Name(), Namespace: a.parent.Namespace(), RESTMapping: a.parent.RESTMapping()}
-	kapplyset := kubectlapply.NewApplySet(parentRef, a.tooling, a.restMapper)
+	kapplyset := kubectlapply.NewApplySet(parentRef, kubectlapply.ApplySetTooling{Name: a.tooling}, a.restMapper)
 
 	// Cache the current RESTMappings to avoid re-fetching the bad ones.
 	restMappings := make(map[schema.GroupVersionKind]restMappingResult)
@@ -375,7 +365,7 @@ func (a *ApplySet) WithParent(ctx context.Context, kapplyset *kubectlapply.Apply
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		annotations[kubectlapply.ApplySetToolingAnnotation] = a.tooling.String()
+		annotations[kubectlapply.ApplySetToolingAnnotation] = a.tooling
 		if _, ok := annotations[kubectlapply.ApplySetGRsAnnotation]; !ok {
 			annotations[kubectlapply.ApplySetGRsAnnotation] = ""
 		}

--- a/applylib/applyset/applyset.go
+++ b/applylib/applyset/applyset.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -70,7 +71,7 @@ type ApplySet struct {
 	// deployment manifests.
 	parent Parent
 	// If not given, the tooling value will be the `Parent` Kind.
-	tooling string
+	tooling kubectlapply.ApplySetTooling
 }
 
 // Options holds the parameters for building an ApplySet.
@@ -93,7 +94,14 @@ type Options struct {
 func New(options Options) (*ApplySet, error) {
 	parent := options.Parent
 	parentRef := &kubectlapply.ApplySetParentRef{Name: parent.Name(), Namespace: parent.Namespace(), RESTMapping: parent.RESTMapping()}
-	kapplyset := kubectlapply.NewApplySet(parentRef, kubectlapply.ApplySetTooling{Name: options.Tooling}, options.RESTMapper)
+
+	toolName, toolVersion, _ := strings.Cut(options.Tooling, "/")
+	if toolName == "" {
+		toolName = parent.GetSubject().GetObjectKind().GroupVersionKind().Kind
+	}
+	tooling := kubectlapply.ApplySetTooling{Name: toolName, Version: toolVersion}
+
+	kapplyset := kubectlapply.NewApplySet(parentRef, tooling, options.RESTMapper)
 	if options.PatchOptions.FieldManager == "" {
 		options.PatchOptions.FieldManager = kapplyset.FieldManager()
 	}
@@ -105,7 +113,7 @@ func New(options Options) (*ApplySet, error) {
 		deleteOptions: options.DeleteOptions,
 		prune:         options.Prune,
 		parent:        parent,
-		tooling:       options.Tooling,
+		tooling:       tooling,
 	}
 	a.trackers = &objectTrackerList{}
 	return a, nil
@@ -149,7 +157,7 @@ func (a *ApplySet) ApplyOnce(ctx context.Context) (*ApplyResults, error) {
 	// single actuation and not for reconciliation.
 	// Note: The Kubectl ApplySet will share the RESTMapper with k-d-p/ApplySet, which caches all the manifests in the past.
 	parentRef := &kubectlapply.ApplySetParentRef{Name: a.parent.Name(), Namespace: a.parent.Namespace(), RESTMapping: a.parent.RESTMapping()}
-	kapplyset := kubectlapply.NewApplySet(parentRef, kubectlapply.ApplySetTooling{Name: a.tooling}, a.restMapper)
+	kapplyset := kubectlapply.NewApplySet(parentRef, a.tooling, a.restMapper)
 
 	// Cache the current RESTMappings to avoid re-fetching the bad ones.
 	restMappings := make(map[schema.GroupVersionKind]restMappingResult)
@@ -365,7 +373,7 @@ func (a *ApplySet) WithParent(ctx context.Context, kapplyset *kubectlapply.Apply
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
-		annotations[kubectlapply.ApplySetToolingAnnotation] = a.tooling
+		annotations[kubectlapply.ApplySetToolingAnnotation] = a.tooling.String()
 		if _, ok := annotations[kubectlapply.ApplySetGRsAnnotation]; !ok {
 			annotations[kubectlapply.ApplySetGRsAnnotation] = ""
 		}

--- a/applylib/applyset/applyset.go
+++ b/applylib/applyset/applyset.go
@@ -98,6 +98,9 @@ func New(options Options) (*ApplySet, error) {
 	// The tooling string slash cutting is to support the ApplySetTooling struct that kubectlapply.NewApplySet() expects.
 	// For instance, 'kpt/v1.0.0' will map to ApplySetTooling{Name: "kpt", Version: "v1.0.0"}.
 	toolName, toolVersion, _ := strings.Cut(options.Tooling, "/")
+	if toolName == "" {
+		toolName = parent.GetSubject().GetObjectKind().GroupVersionKind().Kind
+	}
 	tooling := kubectlapply.ApplySetTooling{Name: toolName, Version: toolVersion}
 
 	kapplyset := kubectlapply.NewApplySet(parentRef, tooling, options.RESTMapper)

--- a/pkg/test/testreconciler/simpletest/testdata/reconcile/ssa/create/expected-http.yaml
+++ b/pkg/test/testreconciler/simpletest/testdata/reconcile/ssa/create/expected-http.yaml
@@ -257,22 +257,6 @@ Date: (removed)
 
 ---
 
-PUT http://kube-apiserver/apis/addons.example.org/v1alpha1/namespaces/ns1/simpletests/simple1
-Accept: application/json, */*
-Content-Type: application/json
-
-{"apiVersion":"addons.example.org/v1alpha1","kind":"SimpleTest","metadata":{"annotations":{"applyset.kubernetes.io/additional-namespaces":"","applyset.kubernetes.io/contains-group-resources":"configmaps,deployments.apps","applyset.kubernetes.io/tooling":"SimpleTest/"},"creationTimestamp":"2022-01-01T00:00:01Z","labels":{"applyset.kubernetes.io/id":"applyset-xbxAWnAItX3p1Gxrs86F-ZQAGwGoys9xxQGK3IED7bY-v1"},"name":"simple1","namespace":"ns1","resourceVersion":"6","uid":"00000000-0000-0000-0000-000000000002"},"spec":{"channel":"stable"},"status":{"conditions":[{"lastTransitionTime":"2022-01-01T00:00:00Z","message":"all manifests are reconciled.","reason":"Normal","status":"True","type":"Ready"}],"healthy":true,"phase":"Current"}}
-
-200 OK
-Cache-Control: no-cache, private
-Content-Length: 736
-Content-Type: application/json
-Date: (removed)
-
-{"apiVersion":"addons.example.org/v1alpha1","kind":"SimpleTest","metadata":{"annotations":{"applyset.kubernetes.io/additional-namespaces":"","applyset.kubernetes.io/contains-group-resources":"configmaps,deployments.apps","applyset.kubernetes.io/tooling":"SimpleTest/"},"creationTimestamp":"2022-01-01T00:00:01Z","labels":{"applyset.kubernetes.io/id":"applyset-xbxAWnAItX3p1Gxrs86F-ZQAGwGoys9xxQGK3IED7bY-v1"},"name":"simple1","namespace":"ns1","resourceVersion":"6","uid":"00000000-0000-0000-0000-000000000002"},"spec":{"channel":"stable"},"status":{"conditions":[{"lastTransitionTime":"2022-01-01T00:00:00Z","message":"all manifests are reconciled.","reason":"Normal","status":"True","type":"Ready"}],"healthy":true,"phase":"Current"}}
-
----
-
 PATCH http://kube-apiserver/api/v1/namespaces/ns1/configmaps/foo?fieldManager=kdp-test&force=true
 Accept: application/json
 Content-Type: application/apply-patch+yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request fixes an issue where the `updateParentLabelsAndAnnotations` function always updates the parent object. This was due to the `applyset.kubernetes.io/tooling` annotation being set to a different value in the kubectl apply package than what the apply set applier expected.