### PR TITLE
fix: mockapiserver data race in create memorystorage

### DIFF
--- a/mockkubeapiserver/memorystorage_watch.go
+++ b/mockkubeapiserver/memorystorage_watch.go
@@ -63,8 +63,7 @@ func (r *resourceStorage) watch(ctx context.Context, opt WatchOptions, callback 
 
 	// TODO: Only send list if no rv specified?
 
-	// TODO: Locking on r.objects
-
+	r.mutex.Lock()
 	for _, obj := range r.objects {
 		if opt.Namespace != "" {
 			if obj.GetNamespace() != opt.Namespace {
@@ -77,13 +76,12 @@ func (r *resourceStorage) watch(ctx context.Context, opt WatchOptions, callback 
 			klog.Warningf("error sending backfill watch notification; stopping watch: %v", err)
 
 			// remove watch from list
-			r.mutex.Lock()
 			r.watches[pos] = nil
-			r.mutex.Unlock()
 
 			return err
 		}
 	}
+	r.mutex.Unlock()
 
 	return <-w.errChan
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
This PR fixes a data race issue in test where two threads in MockKubeAPIserver memorystorage read/write to the same `resourceInformation`

** Verify**
With this PR, the following command should no longer give the data race warning (see data race log)  
```
 go test -race sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative
```

data race log
```bash
WARNING: DATA RACE
Write at 0x00c000792d50 by goroutine 112:
  runtime.mapaccessK()
      /usr/local/go/src/runtime/map.go:518 +0x1ec
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*MemoryStorage).CreateObject()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/memorystorage.go:194 +0x204
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*postResource).Run()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/postresource.go:72 +0x3d4
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*MockKubeAPIServer).ServeHTTP()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/apiserver.go:334 +0x4680
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2936 +0x548
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1995 +0x8d8
  net/http.(*Server).Serve.func3()
      /usr/local/go/src/net/http/server.go:3089 +0x4c

Previous read at 0x00c000792d50 by goroutine 93:
  runtime.mapdelete()
      /usr/local/go/src/runtime/map.go:695 +0x47c
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*resourceStorage).watch()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/memorystorage_watch.go:68 +0x3a8
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*MemoryStorage).Watch()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/memorystorage_watch.go:23 +0x42c
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*listResource).doWatch()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/listresource.go:111 +0x378
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*listResource).Run()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/listresource.go:61 +0x188
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*MockKubeAPIServer).ServeHTTP()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/apiserver.go:334 +0x4680
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2936 +0x548
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1995 +0x8d8
  net/http.(*Server).Serve.func3()
      /usr/local/go/src/net/http/server.go:3089 +0x4c

Goroutine 112 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3089 +0x620
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*MockKubeAPIServer).StartServing.func1()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/apiserver.go:66 +0x68

Goroutine 93 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3089 +0x620
  sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver.(*MockKubeAPIServer).StartServing.func1()
      /Users/yuwenma/go/src/sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver/apiserver.go:66 +0x68
``` 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

