### PR TITLE
fix: bump ci go to v1.20 and fix goimports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: '1.20'
           stable: true
 
       - run: |
@@ -39,7 +39,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: '1.20'
           stable: true
 
       - run: |
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.19
+        go-version: '1.20'
     - name: Install latest version of Kind
       run: |
         GO111MODULE=on go get sigs.k8s.io/kind

--- a/pkg/patterns/declarative/metrics.go
+++ b/pkg/patterns/declarative/metrics.go
@@ -605,4 +605,5 @@ func (rt recordTrigger) Delete(ctx context.Context, ev event.DeleteEvent, _ work
 	}
 }
 
-func (rt recordTrigger) Generic(ctx context.Context, ev event.GenericEvent, _ workqueue.RateLimitingInterface) {}
+func (rt recordTrigger) Generic(ctx context.Context, ev event.GenericEvent, _ workqueue.RateLimitingInterface) {
+}

--- a/pkg/test/testreconciler/simpletest/controller.go
+++ b/pkg/test/testreconciler/simpletest/controller.go
@@ -94,7 +94,6 @@ func (r *SimpleTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
-	
 
 	// Watch for changes to SimpleTest objects
 	err = c.Watch(source.Kind(mgr.GetCache(), &api.SimpleTest{}), &handler.EnqueueRequestForObject{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
This PR fixes the CI "verify-goimports" and "verify-gomod" which the CI go 1.19 cannot run `go mod tidy` for k-d-p go 1.20 modules.  This currently blocks any upcoming PRs to pass the CI check. 
