### PR TITLE
Create abstraction layer over controller-runtime/client-go versions

### DIFF
--- a/applylib/third_party/forked/github.com/kubernetes/kubectl/pkg/cmd/apply/applyset.go
+++ b/applylib/third_party/forked/github.com/kubernetes/kubectl/pkg/cmd/apply/applyset.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/applylib/third_party/forked/k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Label and annotation keys from the ApplySet specification.

--- a/applylib/third_party/forked/k8s.io/apimachinery/pkg/util/sets/empty.go
+++ b/applylib/third_party/forked/k8s.io/apimachinery/pkg/util/sets/empty.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// Empty is public since it is used by some internal API objects for conversions between external
+// string arrays and internal sets, and conversion logic requires public types today.
+type Empty struct{}

--- a/applylib/third_party/forked/k8s.io/apimachinery/pkg/util/sets/ordered.go
+++ b/applylib/third_party/forked/k8s.io/apimachinery/pkg/util/sets/ordered.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+// ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+// If future releases of Go add new ordered types,
+// this constraint will be modified to include them.
+type ordered interface {
+	integer | float | ~string
+}
+
+// integer is a constraint that permits any integer type.
+// If future releases of Go add new predeclared integer types,
+// this constraint will be modified to include them.
+type integer interface {
+	signed | unsigned
+}
+
+// float is a constraint that permits any floating-point type.
+// If future releases of Go add new predeclared floating-point types,
+// this constraint will be modified to include them.
+type float interface {
+	~float32 | ~float64
+}
+
+// signed is a constraint that permits any signed integer type.
+// If future releases of Go add new predeclared signed integer types,
+// this constraint will be modified to include them.
+type signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// unsigned is a constraint that permits any unsigned integer type.
+// If future releases of Go add new predeclared unsigned integer types,
+// this constraint will be modified to include them.
+type unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}

--- a/applylib/third_party/forked/k8s.io/apimachinery/pkg/util/sets/set.go
+++ b/applylib/third_party/forked/k8s.io/apimachinery/pkg/util/sets/set.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+import (
+	"sort"
+)
+
+// Set is a set of the same type elements, implemented via map[comparable]struct{} for minimal memory consumption.
+type Set[T comparable] map[T]Empty
+
+// cast transforms specified set to generic Set[T].
+func cast[T comparable](s map[T]Empty) Set[T] { return s }
+
+// New creates a Set from a list of values.
+// NOTE: type param must be explicitly instantiated if given items are empty.
+func New[T comparable](items ...T) Set[T] {
+	ss := make(Set[T], len(items))
+	ss.Insert(items...)
+	return ss
+}
+
+// KeySet creates a Set from a keys of a map[comparable](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func KeySet[T comparable, V any](theMap map[T]V) Set[T] {
+	ret := Set[T]{}
+	for keyValue := range theMap {
+		ret.Insert(keyValue)
+	}
+	return ret
+}
+
+// Insert adds items to the set.
+func (s Set[T]) Insert(items ...T) Set[T] {
+	for _, item := range items {
+		s[item] = Empty{}
+	}
+	return s
+}
+
+func Insert[T comparable](set Set[T], items ...T) Set[T] {
+	return set.Insert(items...)
+}
+
+// Delete removes all items from the set.
+func (s Set[T]) Delete(items ...T) Set[T] {
+	for _, item := range items {
+		delete(s, item)
+	}
+	return s
+}
+
+// Clear empties the set.
+// It is preferable to replace the set with a newly constructed set,
+// but not all callers can do that (when there are other references to the map).
+// In some cases the set *won't* be fully cleared, e.g. a Set[float32] containing NaN
+// can't be cleared because NaN can't be removed.
+// For sets containing items of a type that is reflexive for ==,
+// this is optimized to a single call to runtime.mapclear().
+func (s Set[T]) Clear() Set[T] {
+	for key := range s {
+		delete(s, key)
+	}
+	return s
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s Set[T]) Has(item T) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s Set[T]) HasAll(items ...T) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s Set[T]) HasAny(items ...T) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Clone returns a new set which is a copy of the current set.
+func (s Set[T]) Clone() Set[T] {
+	result := make(Set[T], len(s))
+	for key := range s {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Difference returns a set of objects that are not in s2.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s1 Set[T]) Difference(s2 Set[T]) Set[T] {
+	result := New[T]()
+	for key := range s1 {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.SymmetricDifference(s2) = {a3, a4, a5}
+// s2.SymmetricDifference(s1) = {a3, a4, a5}
+func (s1 Set[T]) SymmetricDifference(s2 Set[T]) Set[T] {
+	return s1.Difference(s2).Union(s2.Difference(s1))
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 Set[T]) Union(s2 Set[T]) Set[T] {
+	result := s1.Clone()
+	for key := range s2 {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 Set[T]) Intersection(s2 Set[T]) Set[T] {
+	var walk, other Set[T]
+	result := New[T]()
+	if s1.Len() < s2.Len() {
+		walk = s1
+		other = s2
+	} else {
+		walk = s2
+		other = s1
+	}
+	for key := range walk {
+		if other.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 Set[T]) IsSuperset(s2 Set[T]) bool {
+	for item := range s2 {
+		if !s1.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 Set[T]) Equal(s2 Set[T]) bool {
+	return len(s1) == len(s2) && s1.IsSuperset(s2)
+}
+
+type sortableSliceOfGeneric[T ordered] []T
+
+func (g sortableSliceOfGeneric[T]) Len() int           { return len(g) }
+func (g sortableSliceOfGeneric[T]) Less(i, j int) bool { return less[T](g[i], g[j]) }
+func (g sortableSliceOfGeneric[T]) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
+
+// List returns the contents as a sorted T slice.
+//
+// This is a separate function and not a method because not all types supported
+// by Generic are ordered and only those can be sorted.
+func List[T ordered](s Set[T]) []T {
+	res := make(sortableSliceOfGeneric[T], 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	sort.Sort(res)
+	return res
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s Set[T]) UnsortedList() []T {
+	res := make([]T, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
+// PopAny returns a single element from the set.
+func (s Set[T]) PopAny() (T, bool) {
+	for key := range s {
+		s.Delete(key)
+		return key, true
+	}
+	var zeroValue T
+	return zeroValue, false
+}
+
+// Len returns the size of the set.
+func (s Set[T]) Len() int {
+	return len(s)
+}
+
+func less[T ordered](lhs, rhs T) bool {
+	return lhs < rhs
+}

--- a/commonclient/doc.go
+++ b/commonclient/doc.go
@@ -1,0 +1,3 @@
+// Package commonclient provides version-independent wrappers over controller-runtime and client-go.
+// This enables one codebase to work with multiple versions of controller-runtime.
+package commonclient

--- a/commonclient/factory_cr11.go
+++ b/commonclient/factory_cr11.go
@@ -1,0 +1,57 @@
+//go:build controllerruntime_11 || controllerruntime_12 || controllerruntime_13 || controllerruntime_14
+
+package commonclient
+
+import (
+	"context"
+
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// SourceKind is a version-indendenent abstraction over calling source.Kind
+func SourceKind(cache cache.Cache, obj client.Object) source.SyncingSource {
+	return source.NewKindWithCache(obj, cache)
+}
+
+// WrapEventHandler is a version-indendenent abstraction over handler.EventHandler
+func WrapEventHandler(h EventHandler) handler.EventHandler {
+	return &eventHandlerWithoutContext{h: h}
+}
+
+type eventHandlerWithoutContext struct {
+	h EventHandler
+}
+
+func (h *eventHandlerWithoutContext) Create(ev event.CreateEvent, q workqueue.RateLimitingInterface) {
+	h.h.Create(context.TODO(), ev, q)
+}
+func (h *eventHandlerWithoutContext) Update(ev event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	h.h.Update(context.TODO(), ev, q)
+}
+func (h *eventHandlerWithoutContext) Delete(ev event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	h.h.Delete(context.TODO(), ev, q)
+}
+func (h *eventHandlerWithoutContext) Generic(ev event.GenericEvent, q workqueue.RateLimitingInterface) {
+	h.h.Generic(context.TODO(), ev, q)
+}
+
+// EventHandler is the controller-runtime 0.15 version of EventHandler (with a context argument)
+type EventHandler interface {
+	// Create is called in response to an create event - e.g. Pod Creation.
+	Create(context.Context, event.CreateEvent, workqueue.RateLimitingInterface)
+
+	// Update is called in response to an update event -  e.g. Pod Updated.
+	Update(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface)
+
+	// Delete is called in response to a delete event - e.g. Pod Deleted.
+	Delete(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface)
+
+	// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
+	// external trigger request - e.g. reconcile Autoscaling, or a Webhook.
+	Generic(context.Context, event.GenericEvent, workqueue.RateLimitingInterface)
+}

--- a/commonclient/factory_cr15.go
+++ b/commonclient/factory_cr15.go
@@ -1,0 +1,22 @@
+//go:build !(controllerruntime_11 || controllerruntime_12 || controllerruntime_13 || controllerruntime_14)
+
+package commonclient
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// SourceKind is a version-indendenent abstraction over calling source.Kind
+func SourceKind(cache cache.Cache, obj client.Object) source.Source {
+	return source.Kind(cache, obj)
+}
+
+// WrapEventHandler is a version-indendenent abstraction over handler.EventHandler
+func WrapEventHandler(h handler.EventHandler) handler.EventHandler {
+	return h
+}
+
+type EventHandler = handler.EventHandler

--- a/commonclient/restmapper_cr11.go
+++ b/commonclient/restmapper_cr11.go
@@ -1,0 +1,16 @@
+//go:build controllerruntime_11 || controllerruntime_12 || controllerruntime_13 || controllerruntime_14
+
+package commonclient
+
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// NewDiscoveryRESTMapper is a version-independent wrapper around apiutil.NewDiscoveryRESTMapper
+func NewDiscoveryRESTMapper(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
+	return apiutil.NewDiscoveryRESTMapper(c)
+}

--- a/commonclient/restmapper_cr15.go
+++ b/commonclient/restmapper_cr15.go
@@ -1,0 +1,16 @@
+//go:build !(controllerruntime_11 || controllerruntime_12 || controllerruntime_13 || controllerruntime_14)
+
+package commonclient
+
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// NewDiscoveryRESTMapper is a version-independent wrapper around apiutil.NewDiscoveryRESTMapper
+func NewDiscoveryRESTMapper(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
+	return apiutil.NewDiscoveryRESTMapper(c, httpClient)
+}

--- a/pkg/patterns/declarative/metrics.go
+++ b/pkg/patterns/declarative/metrics.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/commonclient"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
 )
 
@@ -351,9 +352,9 @@ func newGVKTracker(mgr manager.Manager, obj *unstructured.Unstructured, namespac
 	gvkt = &gvkTracker{}
 	gvkt.list = newItems()
 	gvkt.recorder = objectRecorderFor(obj.GroupVersionKind())
-	gvkt.src = source.Kind(mgr.GetCache(), obj)
+	gvkt.src = commonclient.SourceKind(mgr.GetCache(), obj)
 	gvkt.predicate = predicate.Funcs{}
-	gvkt.eventHandler = recordTrigger{gvkt.list, namespaced, gvkt.recorder}
+	gvkt.eventHandler = commonclient.WrapEventHandler(recordTrigger{gvkt.list, namespaced, gvkt.recorder})
 
 	return
 }
@@ -531,7 +532,7 @@ func (r record) DeleteIfNeeded(name string, limit int) bool {
 	return false
 }
 
-var _ handler.EventHandler = recordTrigger{}
+var _ commonclient.EventHandler = recordTrigger{}
 
 type recordTrigger struct {
 	list       *items

--- a/pkg/patterns/declarative/pkg/applier/applylib_test.go
+++ b/pkg/patterns/declarative/pkg/applier/applylib_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/applylib/applyset"
@@ -91,14 +90,9 @@ func runApplierGoldenTests(t *testing.T, testDir string, interceptHTTPServer boo
 			t.Errorf("error parsing manifest %q: %v", p, err)
 		}
 
-		c, err := restclient.HTTPClientFor(restConfig)
+		restMapper, err := restmapper.NewForTest(restConfig)
 		if err != nil {
-			t.Fatalf("error from HTTClientFor: %v", err)
-		}
-
-		restMapper, err := restmapper.NewControllerRESTMapper(restConfig, c)
-		if err != nil {
-			t.Fatalf("error from controllerrestmapper.NewControllerRESTMapper: %v", err)
+			t.Fatalf("error from controllerrestmapper.NewForTest: %v", err)
 		}
 
 		parent := fakeParent()

--- a/pkg/patterns/declarative/pkg/applier/global.go
+++ b/pkg/patterns/declarative/pkg/applier/global.go
@@ -1,5 +1,5 @@
-//go:build !without_exec_applier || !without_direct_applier
-// +build !without_exec_applier !without_direct_applier
+//go:build !without_direct_applier
+// +build !without_direct_applier
 
 package applier
 

--- a/pkg/patterns/declarative/pkg/applier/global_without_kubectl.go
+++ b/pkg/patterns/declarative/pkg/applier/global_without_kubectl.go
@@ -1,5 +1,5 @@
-//go:build without_exec_applier && without_direct_applier
-// +build without_exec_applier,without_direct_applier
+//go:build without_direct_applier
+// +build without_direct_applier
 
 package applier
 

--- a/pkg/patterns/declarative/watch.go
+++ b/pkg/patterns/declarative/watch.go
@@ -29,11 +29,11 @@ import (
 	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/commonclient"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/watch"
 )
 
@@ -105,7 +105,7 @@ func WatchChildren(options WatchChildrenOptions) error {
 		if err != nil {
 			return err
 		}
-		rm, err := apiutil.NewDiscoveryRESTMapper(options.RESTConfig, client)
+		rm, err := commonclient.NewDiscoveryRESTMapper(options.RESTConfig, client)
 		if err != nil {
 			return err
 		}

--- a/pkg/restmapper/controllerrestmapper.go
+++ b/pkg/restmapper/controllerrestmapper.go
@@ -3,26 +3,11 @@ package restmapper
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
 )
-
-// NewControllerRESTMapper is the constructor for a ControllerRESTMapper
-func NewControllerRESTMapper(cfg *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
-	discoveryClient, err := discovery.NewDiscoveryClientForConfigAndClient(cfg, httpClient)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ControllerRESTMapper{
-		uncached: discoveryClient,
-		cache:    newCache(),
-	}, nil
-}
 
 // ControllerRESTMapper is a meta.RESTMapper that is optimized for controllers.
 // It caches results in memory, and minimizes discovery because we don't need shortnames etc in controllers.

--- a/pkg/restmapper/controllerrestmapper_cr11.go
+++ b/pkg/restmapper/controllerrestmapper_cr11.go
@@ -1,0 +1,34 @@
+//go:build controllerruntime_11 || controllerruntime_12 || controllerruntime_13 || controllerruntime_14
+
+package restmapper
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// NewControllerRESTMapper is the constructor for a ControllerRESTMapper.
+func NewControllerRESTMapper(restConfig *rest.Config) (meta.RESTMapper, error) {
+	httpClient, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error from HTTPClientFor: %w", err)
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfigAndClient(restConfig, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ControllerRESTMapper{
+		uncached: discoveryClient,
+		cache:    newCache(),
+	}, nil
+}
+
+// NewForTest creates a ControllerRESTMapper, but is intended to be a common interface for use by tests.
+func NewForTest(cfg *rest.Config) (meta.RESTMapper, error) {
+	return NewControllerRESTMapper(cfg)
+}

--- a/pkg/restmapper/controllerrestmapper_cr15.go
+++ b/pkg/restmapper/controllerrestmapper_cr15.go
@@ -1,0 +1,34 @@
+//go:build !(controllerruntime_11 || controllerruntime_12 || controllerruntime_13 || controllerruntime_14)
+
+package restmapper
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// NewControllerRESTMapper is the constructor for a ControllerRESTMapper
+func NewControllerRESTMapper(cfg *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfigAndClient(cfg, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ControllerRESTMapper{
+		uncached: discoveryClient,
+		cache:    newCache(),
+	}, nil
+}
+
+// NewForTest creates a ControllerRESTMapper, but is intended to be a common interface for use by tests.
+func NewForTest(restConfig *rest.Config) (meta.RESTMapper, error) {
+	client, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error from rest.HTTPClientFor: %w", err)
+	}
+	return NewControllerRESTMapper(restConfig, client)
+}

--- a/pkg/restmapper/controllerrestmapper_test.go
+++ b/pkg/restmapper/controllerrestmapper_test.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver"
 )
@@ -39,13 +38,9 @@ func TestRESTMapping(t *testing.T) {
 		Host: addr.String(),
 	}
 
-	client, err := restclient.HTTPClientFor(restConfig)
+	restMapper, err := NewForTest(restConfig)
 	if err != nil {
-		t.Fatalf("error from HTTClientFor: %v", err)
-	}
-	restMapper, err := NewControllerRESTMapper(restConfig, client)
-	if err != nil {
-		t.Fatalf("error from NewControllerRESTMapper: %v", err)
+		t.Fatalf("error from NewForTest: %v", err)
 	}
 	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
 	restMapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)

--- a/pkg/test/testreconciler/simpletest/controller.go
+++ b/pkg/test/testreconciler/simpletest/controller.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/commonclient"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/applier"
@@ -96,7 +96,7 @@ func (r *SimpleTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Watch for changes to SimpleTest objects
-	err = c.Watch(source.Kind(mgr.GetCache(), &api.SimpleTest{}), &handler.EnqueueRequestForObject{})
+	err = c.Watch(commonclient.SourceKind(mgr.GetCache(), &api.SimpleTest{}), &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Create an abstraction layer so that we are less dependent on a particular version of client-go / controller-runtime.  The intent here is that controllers can work with multiple versions of client-go/controller-runtime, and thus a wide range of k8s versions.

- Make our applyset not depend on generics
- Create commonclient to abstract controller-runtime versions