### PR TITLE
fix: remove client-side validation from example guestbook operator

### DIFF
--- a/examples/guestbook-operator/controllers/guestbook_controller.go
+++ b/examples/guestbook-operator/controllers/guestbook_controller.go
@@ -62,7 +62,6 @@ func (r *GuestbookReconciler) setupReconciler(mgr ctrl.Manager) error {
 		declarative.WithApplyKustomize(),
 
 		// Add other optional options for testing
-		declarative.WithApplyValidation(),
 		declarative.WithReconcileMetrics(0, nil),
 	)
 }


### PR DESCRIPTION
This pull request removes the client-side apply validation from the example guestbook operator allowing the operator to successfully reconcile changes.

Previously the operator would show this error when reconciling:
```
2023-10-22T21:39:20-07:00       ERROR   applying manifest       {"controller": "guestbook-controller", "object": {"name":"guestbook-sample","namespace":"default"}, "namespace": "default", "name": "guestbook-sample", "reconcileID": "1063a260-c92e-43ea-b82f-cf2114cdbeef", "error": "client-side validation is no longer supported"}
```

This error is due to client-side validation being deprecated in the direct applier with #352.