### PR TITLE
Enable backwards-compatibility with controller-runtime v0.15

### DIFF
--- a/commonclient/metrics_cr11.go
+++ b/commonclient/metrics_cr11.go
@@ -1,0 +1,19 @@
+//go:build controllerruntime_11 || controllerruntime_12 || controllerruntime_13 || controllerruntime_14 || controllerruntime_15
+
+package commonclient
+
+import (
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// SetMetricsBindAddress sets the metrics address on options independent of
+// manager options version
+func SetMetricsBindAddress(options *ctrl.Options, bindAddress string) error {
+	if options == nil {
+		return fmt.Errorf("unable to set metrics bind address on non-existent manager options")
+	}
+	options.MetricsBindAddress = bindAddress
+	return nil
+}

--- a/commonclient/metrics_cr16.go
+++ b/commonclient/metrics_cr16.go
@@ -1,0 +1,19 @@
+//go:build !(controllerruntime_11 || controllerruntime_12 || controllerruntime_13 || controllerruntime_14 || controllerruntime_15)
+
+package commonclient
+
+import (
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// SetMetricsBindAddress sets the metrics address on options independent of
+// manager options version
+func SetMetricsBindAddress(options *ctrl.Options, bindAddress string) error {
+	if options == nil {
+		return fmt.Errorf("unable to set metrics bind address on non-existent manager options")
+	}
+	options.Metrics.BindAddress = bindAddress
+	return nil
+}

--- a/pkg/patterns/declarative/metrics_test.go
+++ b/pkg/patterns/declarative/metrics_test.go
@@ -38,11 +38,11 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/kubebuilder-declarative-pattern/applylib/applyset"
+	"sigs.k8s.io/kubebuilder-declarative-pattern/commonclient"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/mockkubeapiserver"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/applier"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative/pkg/manifest"
@@ -277,10 +277,10 @@ func TestAddIfNotPresent(t *testing.T) {
 	}
 
 	// Create manager
-	mgrOpt := manager.Options{
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // Disable the metrics server, don't open unneeded ports
-		},
+	mgrOpt := manager.Options{}
+	err = commonclient.SetMetricsBindAddress(&mgrOpt, "0")
+	if err != nil {
+		t.Error(err)
 	}
 	mgr, err := manager.New(restConfig, mgrOpt)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the code backwards-compatible with versions of controller-runtime before 0.16, which introduced the [metrics/server](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/metrics/server) package that kdp now uses. The PR uses `//go:build` to segregate handling of the metrics configuration depending on the version of controller-runtime.

**Special notes for your reviewer**:

N/A

**Additional documentation**:

The following links may be useful references
* When kdp updated to controller-runtime v0.16: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/pull/352
* Previous example of `//go:build` usage: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/pull/342
* Usage of metrics/server in codebase: https://github.com/search?q=repo%3Akubernetes-sigs%2Fkubebuilder-declarative-pattern+%22sigs.k8s.io%2Fcontroller-runtime%2Fpkg%2Fmetrics%2Fserver%22&type=code

