### PR TITLE
Allow dynamic client to be set

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/applylib.go
+++ b/pkg/patterns/declarative/pkg/applier/applylib.go
@@ -54,9 +54,13 @@ func (a *ApplySetApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 
 	patchOptions.Force = &opt.Force
 
-	dynamicClient, err := dynamic.NewForConfig(opt.RESTConfig)
-	if err != nil {
-		return fmt.Errorf("error building dynamic client: %w", err)
+	dynamicClient := opt.DynamicClient
+	if dynamicClient == nil {
+		d, err := dynamic.NewForConfig(opt.RESTConfig)
+		if err != nil {
+			return fmt.Errorf("error building dynamic client: %w", err)
+		}
+		dynamicClient = d
 	}
 
 	restMapper := opt.RESTMapper

--- a/pkg/patterns/declarative/pkg/applier/type.go
+++ b/pkg/patterns/declarative/pkg/applier/type.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/applylib/applyset"
@@ -39,4 +40,8 @@ type ApplierOptions struct {
 
 	ParentRef applyset.Parent
 	Client    client.Client
+
+	// DynamicClient, if set, will be used for applying additional objects.
+	// If not set, a dynamic client will be built from RESTConfig.
+	DynamicClient dynamic.Interface
 }


### PR DESCRIPTION
This allows us to override the dynamic client, useful for tests or if
we want to intercept and track all the calls (for automatic dependency
tracking).
