### PR TITLE
Extract GVK more robustly when building applyset parent

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/applylib.go
+++ b/pkg/patterns/declarative/pkg/applier/applylib.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/applylib/applyset"
@@ -125,8 +126,7 @@ func (a *ApplySetApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 }
 
 // NewParentRef maps a declarative object's information to the ParentRef defined in the applyset library.
-func NewParentRef(restMapper meta.RESTMapper, object runtime.Object, name, namespace string) (applyset.Parent, error) {
-	gvk := object.GetObjectKind().GroupVersionKind()
+func NewParentRef(restMapper meta.RESTMapper, object runtime.Object, gvk schema.GroupVersionKind, name, namespace string) (applyset.Parent, error) {
 	restMapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return nil, err

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -370,9 +370,13 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 		}
 	}
 
-	parentRef, err := applier.NewParentRef(r.restMapper, instance, instance.GetName(), instance.GetNamespace())
+	gvk, err := apiutil.GVKForObject(instance, r.mgr.GetScheme())
 	if err != nil {
-		return statusInfo, err
+		return statusInfo, fmt.Errorf("getting GVK for %T: %w", instance, err)
+	}
+	parentRef, err := applier.NewParentRef(r.restMapper, instance, gvk, instance.GetName(), instance.GetNamespace())
+	if err != nil {
+		return statusInfo, fmt.Errorf("building applyset parent: %w", err)
 	}
 	applierOpt := applier.ApplierOptions{
 		RESTConfig:        r.config,


### PR DESCRIPTION
Include the case when we're using a typed object.
