### PR TITLE
feat: kStatusAggregator user supplied gvk compute and abnormal conditions fns

### DIFF
--- a/pkg/patterns/addon/pkg/status/kstatus.go
+++ b/pkg/patterns/addon/pkg/status/kstatus.go
@@ -43,11 +43,11 @@ type kstatusAggregator struct {
 //
 // e.g.
 // computMethods := make(map[string]GetConditionsFn)
-// conditionsMethods := make(map[string]AbnormalConditionsMethod)
+// abnormalConditionsMethods := make(map[string]AbnormalConditionsMethod)
 //
 // resourceGVK := schema.GroupVersionKind{...}
 // computMethods[resourceGVK.String()] = <user supplied gvk specific 'Compute' method>
-// conditionsMethods[resourceGVK.String()] = <user supplied gvk specific Abnormal Conditions method>
+// abnormalConditionsMethods[resourceGVK.String()] = <user supplied gvk specific Abnormal Conditions method>
 //
 //	statusBuilder := &declarative.StatusBuilder  {
 //		BuildStatusImpl: status.NewOpenKStatusAggregator(computeMethods, abnormalConditionsMethods),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
This PR extends the kStatusAggregator to support user supplied gvk specific compute and abnormal conditions functions allowing users to support aggregate status without implementing an entire build status method.

Details and summary documented in [issue 365](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/issues/365)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #365 

**Special notes for your reviewer**:

**Additional documentation**:

