### PR TITLE
Switch to after apply when setting up watches

### DIFF
--- a/pkg/patterns/declarative/watch.go
+++ b/pkg/patterns/declarative/watch.go
@@ -151,8 +151,8 @@ type clusterWatch struct {
 	registered map[string]struct{}
 }
 
-// BeforeApply is called by the controller before an apply. We establish any new watches that will be needed by the apply.
-func (w *clusterWatch) BeforeApply(ctx context.Context, op *ApplyOperation) error {
+// AfterApply is called by the controller after an apply. We establish any new watches that will be needed by the apply.
+func (w *clusterWatch) AfterApply(ctx context.Context, op *ApplyOperation) error {
 	log := log.FromContext(ctx)
 
 	labelSelector, err := labels.ValidatedSelectorFromSet(w.labelMaker(ctx, op.Subject))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**: 
This change is to workaround a potential bug where we are setting up watches in a namespace that is not yet created by apply.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

