### PR TITLE
Track info.Err in the status field

### DIFF
--- a/pkg/patterns/addon/pkg/status/kstatus.go
+++ b/pkg/patterns/addon/pkg/status/kstatus.go
@@ -87,7 +87,9 @@ func (k *kstatusAggregator) BuildStatus(ctx context.Context, info *declarative.S
 	}
 
 	shouldComputeHealthFromObjects := info.Manifest != nil && info.LiveObjects != nil
+	currentStatus.Errors = []string{}
 	if info.Err != nil {
+		currentStatus.Errors = []string{info.Err.Error()}
 		switch info.KnownError {
 		case declarative.KnownErrorApplyFailed:
 			currentStatus.Phase = "Applying"


### PR DESCRIPTION
This allows the reconcilation errors such as errors encountered in the object transformers to be tracked in the field `status.errors`.

Currently, if errors happens during the execution of an object tranformer, the status field is set to:
```
status:
  healthy: false
  phase: InternalError
```

With this CL, the reconciliation errors  are tracked in the field `status.errors`:
```
status:
  errors:
  - 'error building deployment objects: a test error'
  healthy: false
  phase: InternalError
```
