### PR TITLE
Add a kubebuilder marker to patches to preserve unknow fields

### DIFF
--- a/pkg/patterns/addon/pkg/apis/v1alpha1/common_types.go
+++ b/pkg/patterns/addon/pkg/apis/v1alpha1/common_types.go
@@ -57,5 +57,6 @@ type Patchable interface {
 
 // +k8s:deepcopy-gen=true
 type PatchSpec struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Patches []*runtime.RawExtension `json:"patches,omitempty"`
 }


### PR DESCRIPTION
https://book.kubebuilder.io/reference/markers/crd-processing

Currently, a MOSS controller does not support patches correctly by default. For example, applying the following object would get an error `strict decoding error: unknown field "spec.patches[0].apiVersion", unknown field "spec.patches[0].kind", unknown field "spec.patches[0].metadata", unknown field "spec.patches[0].spec"`.

```
apiVersion: configdelivery.gke.io/v1beta1
kind: ConfigSync
metadata:
  name: config-sync
spec:
  version: 1.16.1
  patches:
  - apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: reconciler-manager
      namespace: config-management-system
    spec:
      template:
        spec:
          containers:
          - name: reconciler-manager
            resources:
              limits:
                memory: "1Gi"
```

To fix this, we need to add `x-kubernetes-preserve-unknown-fields: true` into the `patches` field of ConfigSync CRD:

```
              patches:
                items:
                  type: object
                type: array
                x-kubernetes-preserve-unknown-fields: true
```

