### PR TITLE
Expose more health info as well as counts in Apply results

### DIFF
--- a/applylib/applyset/applyset.go
+++ b/applylib/applyset/applyset.go
@@ -257,8 +257,9 @@ func (a *ApplySet) ApplyOnce(ctx context.Context) (*ApplyResults, error) {
 		visitedUids.Insert(lastApplied.GetUID())
 		tracker.lastApplied = lastApplied
 		results.applySuccess(gvk, nn)
-		tracker.isHealthy = isHealthy(lastApplied)
-		results.reportHealth(gvk, nn, tracker.isHealthy)
+		message := ""
+		tracker.isHealthy, message = isHealthy(lastApplied)
+		results.reportHealth(gvk, nn, tracker.isHealthy, message)
 	}
 
 	// We want to be more cautions on pruning and only do it if all manifests are applied.

--- a/applylib/applyset/health.go
+++ b/applylib/applyset/health.go
@@ -26,27 +26,27 @@ import (
 
 // isHealthy reports whether the object should be considered "healthy"
 // TODO: Replace with kstatus library
-func isHealthy(u *unstructured.Unstructured) bool {
+func isHealthy(u *unstructured.Unstructured) (bool, string) {
 	result, err := status.Compute(u)
 	if err != nil {
 		klog.Infof("unable to compute condition for %s", humanName(u))
-		return false
+		return false, result.Message
 	}
 	switch result.Status {
 	case status.InProgressStatus:
-		return false
+		return false, result.Message
 	case status.FailedStatus:
-		return false
+		return false, result.Message
 	case status.TerminatingStatus:
-		return false
+		return false, result.Message
 	case status.UnknownStatus:
 		klog.Warningf("unknown status for %s", humanName(u))
-		return false
+		return false, result.Message
 	case status.CurrentStatus:
-		return true
+		return true, result.Message
 	default:
 		klog.Warningf("unknown status value %s", result.Status)
-		return false
+		return false, result.Message
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose more health info as well as counts in Apply results
When using applyset as a library we sometimes want more information about the last applied set.
Currently we get boolean (IsHealthy, IsAllApplied).
Having more is useful when consuming this as a library.