### PR TITLE
feat: Enable server-side-apply on direct applier

### DIFF
--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -27,13 +27,20 @@ import (
 )
 
 type DirectApplier struct {
-	inner directApplierSite
+	// Whether to apply the KRM resources using server-side apply. https://kubernetes.io/docs/reference/using-api/server-side-apply/
+	// Note: The server-side apply is stable in Kubernetes v1.22, users should take the responsibility to make sure the cluster
+	// server can support this feature.
+	serverSideApplyPreferred bool
+	inner                    directApplierSite
+}
+
+func (d *DirectApplier) UseServerSideApply() {
+	d.serverSideApplyPreferred = true
 }
 
 var _ Applier = &DirectApplier{}
 
-type directApplier struct {
-}
+type directApplier struct{}
 
 type directApplierSite interface {
 	Run(a *apply.ApplyOptions) error
@@ -170,7 +177,7 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 		applyOpts.PruneResources = append(applyOpts.PruneResources, r...)
 	}
 
-	applyOpts.ServerSideApply = true
+	applyOpts.ServerSideApply = d.serverSideApplyPreferred
 	applyOpts.ForceConflicts = opt.Force
 	applyOpts.Namespace = opt.Namespace
 	applyOpts.SetObjects(infos)

--- a/pkg/patterns/declarative/pkg/applier/direct.go
+++ b/pkg/patterns/declarative/pkg/applier/direct.go
@@ -170,6 +170,7 @@ func (d *DirectApplier) Apply(ctx context.Context, opt ApplierOptions) error {
 		applyOpts.PruneResources = append(applyOpts.PruneResources, r...)
 	}
 
+	applyOpts.ServerSideApply = true
 	applyOpts.ForceConflicts = opt.Force
 	applyOpts.Namespace = opt.Namespace
 	applyOpts.SetObjects(infos)


### PR DESCRIPTION
This will fix the  "annotation too long" problem when the managed manifests are too large.

<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Additional documentation**:

