### PR TITLE
chore: stage ktest module

### DIFF
--- a/ktest/doc.go
+++ b/ktest/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktest
+
+// Package ktest implements shared helper functions for testing kubernetes controllers

--- a/ktest/go.mod
+++ b/ktest/go.mod
@@ -1,0 +1,5 @@
+module sigs.k8s.io/kubebuilder-declarative-pattern/ktest
+
+go 1.21
+
+toolchain go1.22.0


### PR DESCRIPTION
This should enable us to add a module much more easily, because `go
mod tidy` will work.
