### PR TITLE
propagate error that occurs during health computation

### DIFF
--- a/applylib/applyset/applyset.go
+++ b/applylib/applyset/applyset.go
@@ -36,7 +36,7 @@ import (
 	kubectlapply "sigs.k8s.io/kubebuilder-declarative-pattern/applylib/forked/github.com/kubernetes/kubectl/pkg/cmd/apply"
 )
 
-type ComputeHealthCallback func(*unstructured.Unstructured) (bool, string)
+type ComputeHealthCallback func(*unstructured.Unstructured) (bool, string, error)
 
 // ApplySet is a set of objects that we want to apply to the cluster.
 //
@@ -270,8 +270,8 @@ func (a *ApplySet) ApplyOnce(ctx context.Context) (*ApplyResults, error) {
 		tracker.lastApplied = lastApplied
 		results.applySuccess(gvk, nn)
 		message := ""
-		tracker.isHealthy, message = a.computeHealth(lastApplied)
-		results.reportHealth(gvk, nn, tracker.isHealthy, message)
+		tracker.isHealthy, message, err = a.computeHealth(lastApplied)
+		results.reportHealth(gvk, nn, tracker.isHealthy, message, err)
 	}
 
 	// We want to be more cautions on pruning and only do it if all manifests are applied.

--- a/applylib/applyset/health.go
+++ b/applylib/applyset/health.go
@@ -25,27 +25,27 @@ import (
 )
 
 // IsHealthy reports whether the object should be considered "healthy"
-func IsHealthy(u *unstructured.Unstructured) (bool, string) {
+func IsHealthy(u *unstructured.Unstructured) (bool, string, error) {
 	result, err := status.Compute(u)
 	if err != nil {
 		klog.Infof("unable to compute condition for %s", humanName(u))
-		return false, result.Message
+		return false, result.Message, err
 	}
 	switch result.Status {
 	case status.InProgressStatus:
-		return false, result.Message
+		return false, result.Message, nil
 	case status.FailedStatus:
-		return false, result.Message
+		return false, result.Message, nil
 	case status.TerminatingStatus:
-		return false, result.Message
+		return false, result.Message, nil
 	case status.UnknownStatus:
 		klog.Warningf("unknown status for %s", humanName(u))
-		return false, result.Message
+		return false, result.Message, nil
 	case status.CurrentStatus:
-		return true, result.Message
+		return true, result.Message, nil
 	default:
 		klog.Warningf("unknown status value %s", result.Status)
-		return false, result.Message
+		return false, result.Message, nil
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Capture error as part of health computation and propagate it to health tracker. This will be returned to the caller as part of object result
