### PR TITLE
chore: get go version from go.mod

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,12 @@ jobs:
   verify-goimports:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: Set up go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-          stable: true
-
-      - uses: actions/checkout@v2
+          go-version-file: 'go.mod'
 
       - name: verify-goimports
         run: dev/ci/presubmits/verify-goimports
@@ -26,13 +25,12 @@ jobs:
   verify-gomod:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: Set up go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-          stable: true
-
-      - uses: actions/checkout@v2
+          go-version-file: 'go.mod'
 
       - name: verify-gomod
         run: dev/ci/presubmits/verify-gomod
@@ -44,7 +42,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version-file: 'go.mod'
     - name: Install latest version of Kind
       run: |
         go get sigs.k8s.io/kind


### PR DESCRIPTION
This avoids needing to update the go version in multiple places.
