### PR TITLE
derive controller name from prototype and allow custom name

### DIFF
--- a/pkg/patterns/addon/pkg/utils/helpers_test.go
+++ b/pkg/patterns/addon/pkg/utils/helpers_test.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	addonsv1alpha1 "sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/apis/v1alpha1"
+)
+
+type mockCommonObject struct {
+	addonsv1alpha1.CommonObject
+	name string
+}
+
+func (m *mockCommonObject) ComponentName() string {
+	return m.name
+}
+
+func TestGetCommonName(t *testing.T) {
+	type args struct {
+		instance runtime.Object
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "CommonObject instance",
+			args: args{
+				instance: &mockCommonObject{name: "test-component"},
+			},
+			want:    "test-component",
+			wantErr: false,
+		},
+		{
+			name: "Unstructured instance",
+			args: args{
+				instance: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "TestKind",
+					},
+				},
+			},
+			want:    "testkind",
+			wantErr: false,
+		},
+		{
+			name: "Invalid instance",
+			args: args{
+				instance: &runtime.Unknown{},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetCommonName(tt.args.instance)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCommonName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetCommonName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -106,10 +106,17 @@ func (e *ErrorResult) Error() string {
 var defaultApplier = applier.DefaultApplier
 
 func (r *Reconciler) Init(mgr manager.Manager, prototype DeclarativeObject, opts ...ReconcilerOption) error {
+	controllerName := "addon-controller"
+	if commonName, err := utils.GetCommonName(prototype); err == nil {
+		controllerName = commonName + "-controller"
+	}
+
+	return r.InitWithName(mgr, prototype, controllerName, opts...)
+}
+
+func (r *Reconciler) InitWithName(mgr manager.Manager, prototype DeclarativeObject, controllerName string, opts ...ReconcilerOption) error {
 	r.prototype = prototype
 
-	// TODO: Can we derive the name from prototype?
-	controllerName := "addon-controller"
 	r.recorder = mgr.GetEventRecorderFor(controllerName)
 
 	r.client = mgr.GetClient()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/blob/master/CONTRIBUTING.md
-->

**What this PR does / why we need it**:
This PR add a new InitWithName function that allow passing in a custom controller name, and changes the default name to be inferred from the prototype when possible.

**Special notes for your reviewer**:
It's my first contribution and first time with Go so reviews are welcome.

**Additional documentation**:
Change should simple enough to be self explanatory.

