### PR TITLE
chore: update version of kubectl used in tests

### DIFF
--- a/dev/update-golden
+++ b/dev/update-golden
@@ -13,7 +13,7 @@ cd "${REPO_ROOT}"
 if [[ ! -f "bin/kubectl" ]]; then
   echo "Downloading kubectl to bin/kubectl"
   mkdir -p bin/
-  curl -L -o bin/kubectl https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl
+  curl -L -o bin/kubectl https://dl.k8s.io/release/v1.32.1/bin/linux/amd64/kubectl
 fi
 chmod +x bin/kubectl
 export PATH="${REPO_ROOT}/bin:$PATH"

--- a/hack/ci/test.sh
+++ b/hack/ci/test.sh
@@ -31,7 +31,7 @@ REPO_ROOT=$(pwd)
 if [[ ! -f "bin/kubectl" ]]; then
   echo "Downloading kubectl to bin/kubectl"
   mkdir -p bin/
-  curl -L -o bin/kubectl https://dl.k8s.io/release/v1.27.0/bin/linux/amd64/kubectl
+  curl -L -o bin/kubectl https://dl.k8s.io/release/v1.32.1/bin/linux/amd64/kubectl
 fi
 chmod +x bin/kubectl
 export PATH="${REPO_ROOT}/bin:$PATH"

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple1/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple1/expected-apiserver.yaml
@@ -6,17 +6,8 @@ Accept-Encoding: gzip
 
 ---
 
-GET /openapi/v2?timeout=32s
-Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
----
-
 GET /api?timeout=32s
-Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
+Accept: application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList,application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -34,7 +25,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /apis?timeout=32s
-Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
+Accept: application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList,application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple2/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple2/expected-apiserver.yaml
@@ -6,17 +6,8 @@ Accept-Encoding: gzip
 
 ---
 
-GET /openapi/v2?timeout=32s
-Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
----
-
 GET /api?timeout=32s
-Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
+Accept: application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList,application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -34,7 +25,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /apis?timeout=32s
-Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
+Accept: application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList,application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -233,6 +224,24 @@ Kubectl-Command: kubectl apply
 
 GET /api/v1/namespaces/ns1
 Accept: application/json
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+---
+
+GET /openapi/v3?timeout=32s
+Accept: application/json, */*
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+---
+
+GET /openapi/v2?timeout=32s
+Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 

--- a/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple3/expected-apiserver.yaml
+++ b/pkg/patterns/declarative/pkg/applier/testdata/kubectl/simple3/expected-apiserver.yaml
@@ -6,17 +6,8 @@ Accept-Encoding: gzip
 
 ---
 
-GET /openapi/v2?timeout=32s
-Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
-Accept-Encoding: gzip
-Kubectl-Command: kubectl apply
-
-
-
----
-
 GET /api?timeout=32s
-Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
+Accept: application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList,application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -34,7 +25,7 @@ Kubectl-Command: kubectl apply
 ---
 
 GET /apis?timeout=32s
-Accept: application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
+Accept: application/json;g=apidiscovery.k8s.io;v=v2;as=APIGroupDiscoveryList,application/json;g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList,application/json
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 
@@ -233,6 +224,24 @@ Kubectl-Command: kubectl apply
 
 GET /api/v1/namespaces/ns1
 Accept: application/json
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+---
+
+GET /openapi/v3?timeout=32s
+Accept: application/json, */*
+Accept-Encoding: gzip
+Kubectl-Command: kubectl apply
+
+
+
+---
+
+GET /openapi/v2?timeout=32s
+Accept: application/com.github.proto-openapi.spec.v2@v1.0+protobuf
 Accept-Encoding: gzip
 Kubectl-Command: kubectl apply
 


### PR DESCRIPTION
We want to use newer kubectl versions in general.

This version is also helpful for golden tests because it prefers json over protobuf.
