### PR TITLE
Move per-reconcile and per-resource log messages to V(2)

### DIFF
--- a/pkg/patterns/addon/pkg/loaders/fs.go
+++ b/pkg/patterns/addon/pkg/loaders/fs.go
@@ -105,7 +105,7 @@ func (c *ManifestLoader) ResolveManifest(ctx context.Context, object runtime.Obj
 
 		log.WithValues("channel", channelName).WithValues("version", id).Info("resolved version from channel")
 	} else {
-		log.WithValues("version", version).Info("using specified version")
+		log.WithValues("version", version).V(2).Info("using specified version")
 	}
 	s := make(map[string]string)
 	s, err = c.repo.LoadManifest(ctx, componentName, id)

--- a/pkg/patterns/addon/pkg/loaders/git.go
+++ b/pkg/patterns/addon/pkg/loaders/git.go
@@ -66,7 +66,7 @@ func (r *GitRepository) LoadManifest(ctx context.Context, packageName string, id
 	}
 
 	log := log.FromContext(ctx)
-	log.WithValues("package", packageName).Info("loading package")
+	log.WithValues("package", packageName).V(2).Info("loading package")
 
 	var filePath string
 	if r.subDir == "" {

--- a/pkg/patterns/addon/pkg/loaders/http.go
+++ b/pkg/patterns/addon/pkg/loaders/http.go
@@ -74,7 +74,7 @@ func (r *HTTPRepository) LoadManifest(ctx context.Context, packageName string, i
 	}
 
 	log := log.FromContext(ctx)
-	log.WithValues("package", packageName).Info("loading package")
+	log.WithValues("package", packageName).V(2).Info("loading package")
 
 	p := r.makeURL("packages", packageName, id, "manifest.yaml")
 	b, err := r.readURL(ctx, p)

--- a/pkg/patterns/addon/pkg/loaders/types.go
+++ b/pkg/patterns/addon/pkg/loaders/types.go
@@ -121,7 +121,7 @@ func (r *FSRepository) LoadManifest(ctx context.Context, packageName string, id 
 	}
 
 	log := log.FromContext(ctx)
-	log.WithValues("package", packageName).Info("loading package")
+	log.WithValues("package", packageName).V(2).Info("loading package")
 
 	dirPath := filepath.Join(r.basedir, "packages", packageName, id)
 	filesPath, err := os.ReadDir(dirPath)

--- a/pkg/patterns/addon/pkg/status/kstatus.go
+++ b/pkg/patterns/addon/pkg/status/kstatus.go
@@ -131,7 +131,7 @@ func (k *kstatusAggregator) BuildStatus(ctx context.Context, info *declarative.S
 				log.Error(err, "error getting status of resource")
 				statusMap[status.UnknownStatus] = true
 			} else if res != nil {
-				log.WithValues("status", res.Status).WithValues("message", res.Message).Info("Got status of resource:")
+				log.WithValues("status", res.Status).WithValues("message", res.Message).V(2).Info("Got status of resource:")
 				statusMap[res.Status] = true
 			} else {
 				log.Info("resource status was nil")

--- a/pkg/patterns/declarative/pkg/watch/dynamic.go
+++ b/pkg/patterns/declarative/pkg/watch/dynamic.go
@@ -198,7 +198,7 @@ func (w *dynamicKindWatch) watchUntilClosed(ctx context.Context, eventTarget met
 		return
 	}
 
-	log.WithValues("kind", w.GVK.String()).WithValues("namespace", w.FilterNamespace).WithValues("labels", options.LabelSelector).Info("watch began")
+	log.WithValues("kind", w.GVK.String()).WithValues("namespace", w.FilterNamespace).WithValues("labels", options.LabelSelector).V(2).Info("watch began")
 
 	// Always clean up watchers
 	defer events.Stop()
@@ -231,9 +231,9 @@ func (w *dynamicKindWatch) watchUntilClosed(ctx context.Context, eventTarget met
 			w.lastRV[key] = rv
 		}
 
-		log.WithValues("type", clientEvent.Type).WithValues("kind", w.GVK.String()).WithValues("name", key.Name, "namespace", key.Namespace).Info("broadcasting event")
+		log.WithValues("type", clientEvent.Type).WithValues("kind", w.GVK.String()).WithValues("name", key.Name, "namespace", key.Namespace).V(2).Info("broadcasting event")
 		w.events <- event.GenericEvent{Object: clientObject{Object: clientEvent.Object, ObjectMeta: &eventTarget}}
 	}
 
-	log.WithValues("kind", w.GVK.String()).WithValues("namespace", w.FilterNamespace).WithValues("labels", options.LabelSelector).Info("watch closed")
+	log.WithValues("kind", w.GVK.String()).WithValues("namespace", w.FilterNamespace).WithValues("labels", options.LabelSelector).V(2).Info("watch closed")
 }

--- a/pkg/patterns/declarative/reconciler.go
+++ b/pkg/patterns/declarative/reconciler.go
@@ -289,7 +289,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, original DeclarativeObjec
 
 func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedName, instance DeclarativeObject) (*StatusInfo, error) {
 	log := log.FromContext(ctx)
-	log.WithValues("object", name.String()).Info("reconciling")
+	log.WithValues("object", name.String()).V(2).Info("reconciling")
 
 	statusInfo := &StatusInfo{
 		Subject: instance,
@@ -311,7 +311,7 @@ func (r *Reconciler) reconcileExists(ctx context.Context, name types.NamespacedN
 		log.Error(err, "flattening list objects")
 		return statusInfo, fmt.Errorf("error flattening list objects: %w", err)
 	}
-	log.WithValues("objects", fmt.Sprintf("%d", len(objects.Items))).Info("built deployment objects")
+	log.WithValues("objects", fmt.Sprintf("%d", len(objects.Items))).V(2).Info("built deployment objects")
 	statusInfo.Manifest = objects
 
 	if r.options.status != nil {
@@ -680,7 +680,7 @@ func (r *Reconciler) setNamespaces(ctx context.Context, instance DeclarativeObje
 	}
 
 	log := log.FromContext(ctx)
-	log.WithValues("namespace", ns).Info("setting namespace")
+	log.WithValues("namespace", ns).V(2).Info("setting namespace")
 
 	for _, o := range objects.Items {
 		if o.GetNamespace() != "" {
@@ -706,7 +706,7 @@ func (r *Reconciler) injectOwnerRef(ctx context.Context, instance DeclarativeObj
 	}
 
 	log := log.FromContext(ctx)
-	log.WithValues("object", fmt.Sprintf("%s/%s", instance.GetName(), instance.GetNamespace())).Info("injecting owner references")
+	log.WithValues("object", fmt.Sprintf("%s/%s", instance.GetName(), instance.GetNamespace())).V(2).Info("injecting owner references")
 
 	for _, o := range objects.Items {
 		owner, err := r.options.ownerFn(ctx, instance, *o, *objects)


### PR DESCRIPTION
Several `Info()` log calls emit on every reconcile loop iteration or for every watched resource, even when nothing has changed. At default verbosity these dominate log output and obscure operationally significant messages.

This PR moves these messages from `Info()` (V(0)) to `V(2).Info()`, keeping them available for debugging while reducing noise at default verbosity.

### Messages moved to V(2)

| Message | File | Why |
|---|---|---|
| `Got status of resource:` | `pkg/patterns/addon/pkg/status/kstatus.go` | Logged for every resource on every status check, including no-op "Current" status |
| `watch began` / `watch closed` | `pkg/patterns/declarative/pkg/watch/dynamic.go` | Watch lifecycle bookkeeping |
| `broadcasting event` | `pkg/patterns/declarative/pkg/watch/dynamic.go` | Every individual watch event |
| `reconciling` | `pkg/patterns/declarative/reconciler.go` | Every reconcile loop entry |
| `built deployment objects` | `pkg/patterns/declarative/reconciler.go` | Every reconcile |
| `setting namespace` | `pkg/patterns/declarative/reconciler.go` | Every reconcile |
| `injecting owner references` | `pkg/patterns/declarative/reconciler.go` | Every reconcile |
| `loading package` | `pkg/patterns/addon/pkg/loaders/*.go` | Every reconcile (3 loader implementations) |
| `using specified version` | `pkg/patterns/addon/pkg/loaders/fs.go` | Every reconcile |

### Rationale

The logr library convention is:
- **V(0) / Info()** — operational: state transitions, errors, decisions
- **V(1)** — useful debugging detail
- **V(2)+** — per-iteration, per-resource trace output

These messages are all per-iteration trace output. They don't indicate state changes or problems — they confirm the system is doing its normal work. Operators who need trace-level detail can run with `-v=2`.

### No behavior change

This only affects log output at default verbosity. All messages remain available at V(2). No functional behavior is changed.