### PR TITLE
fix(declarative): correct 'occured' / 'reconcilation' doc typos in Reconciled interface

### DIFF
--- a/pkg/patterns/declarative/status.go
+++ b/pkg/patterns/declarative/status.go
@@ -48,8 +48,8 @@ type Status interface {
 type LiveObjectReader func(ctx context.Context, gvk schema.GroupVersionKind, nn types.NamespacedName) (*unstructured.Unstructured, error)
 
 type Reconciled interface {
-	// Reconciled is triggered when Reconciliation has occured.
-	// The caller is encouraged to determine and surface the health of the reconcilation
+	// Reconciled is triggered when Reconciliation has occurred.
+	// The caller is encouraged to determine and surface the health of the reconciliation
 	// on the DeclarativeObject.
 	//
 	// Deprecated: Prefer the BuildStatus method


### PR DESCRIPTION
Doc comments on the `Reconciled` interface in `pkg/patterns/declarative/status.go:51-52` had two adjacent typos:

```go
// Reconciled is triggered when Reconciliation has occured.
// The caller is encouraged to determine and surface the health of the reconcilation
```

→ `occurred` and `reconciliation`. Doc-only change; `go build ./pkg/patterns/declarative/...` stays clean against current `master`.